### PR TITLE
perf: push etp-find pattern matching into SQLite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2134,6 +2134,7 @@ dependencies = [
  "libsqlite3-sys",
  "log",
  "percent-encoding",
+ "regex",
  "serde",
  "serde_urlencoded",
  "sqlx-core",

--- a/cmd/etp-csv/src/main.rs
+++ b/cmd/etp-csv/src/main.rs
@@ -96,11 +96,12 @@ async fn run(cli: Cli) -> Result<()> {
     );
 
     if let Some(ref find_pattern) = cli.find {
-        let pattern = ops::compile_pattern(find_pattern, cli.insensitive)?;
+        ops::compile_pattern(find_pattern, cli.insensitive)?;
         let matches = ops::collect_find_matches(
             &ctx.pool,
             Some(ctx.scan_id),
-            &pattern,
+            find_pattern,
+            cli.insensitive,
             &cli.exclude,
             &filter,
         )

--- a/cmd/etp-csv/tests/cmd/csv-verbose.stderr
+++ b/cmd/etp-csv/tests/cmd/csv-verbose.stderr
@@ -4,7 +4,7 @@ starting scan: .
 phase: all_directory_mtimes done in [..]s — 0 entries
 scanning: . (4 files)
 phase: final flush_pending done in [..]s
-phase: walk complete in [..]s — dirs_scanned=1, dirs_cached=0, removed_files_accum=0, seen_paths=1
+phase: walk done in [..]s — dirs_scanned=1, dirs_cached=0, removed_files_accum=0, seen_paths=1
 phase: remove_stale_directories done in [..]s — dir_removed=0, stale_orphans=0
 phase: reconcile_moves done in [..]s — orphan_hashes=0
 phase: cas blob cleanup done in [..]s — blobs_removed=0

--- a/cmd/etp-csv/tests/cmd/csv-verbose.stderr
+++ b/cmd/etp-csv/tests/cmd/csv-verbose.stderr
@@ -1,6 +1,13 @@
 creating new database: ./.etp.db
 initializing from clean schema
 starting scan: .
+phase: all_directory_mtimes done in [..]s — 0 entries
 scanning: . (4 files)
+phase: final flush_pending done in [..]s
+phase: walk complete in [..]s — dirs_scanned=1, dirs_cached=0, removed_files_accum=0, seen_paths=1
+phase: remove_stale_directories done in [..]s — dir_removed=0, stale_orphans=0
+phase: reconcile_moves done in [..]s — orphan_hashes=0
+phase: cas blob cleanup done in [..]s — blobs_removed=0
+phase: finish_scan done in [..]s
 scan complete in [..]ms: 0 cached, 1 scanned, 0 removed
 wrote ./index.csv

--- a/cmd/etp-find/src/main.rs
+++ b/cmd/etp-find/src/main.rs
@@ -71,7 +71,9 @@ struct Cli {
 async fn run(cli: Cli) -> Result<()> {
     let config = etp_lib::config::RuntimeConfig::load_or_default();
 
-    let pattern = ops::compile_pattern(&cli.pattern, cli.insensitive)?;
+    // Validate the regex once up front so we fail fast on bad syntax; SQLite
+    // will also refuse bad regex at query time, but this gives a cleaner error.
+    ops::compile_pattern(&cli.pattern, cli.insensitive)?;
 
     // Resolve nicknames on -R/--root and/or --db.
     let (directory, explicit_db) = if let Some(ref dir) = cli.directory {
@@ -170,8 +172,15 @@ async fn run(cli: Cli) -> Result<()> {
 
     if needs_collect {
         // Collect all matches
-        let matches =
-            ops::collect_find_matches(&pool, scan_id, &pattern, &cli.exclude, &filter).await?;
+        let matches = ops::collect_find_matches(
+            &pool,
+            scan_id,
+            &cli.pattern,
+            cli.insensitive,
+            &cli.exclude,
+            &filter,
+        )
+        .await?;
         let count = matches.len();
         let total_size: u64 = matches.iter().map(|m| m.size).sum();
 
@@ -201,8 +210,15 @@ async fn run(cli: Cli) -> Result<()> {
         }
     } else {
         // Stream matches to stdout
-        let (count, total_size) =
-            ops::stream_find_matches(&pool, scan_id, &pattern, &cli.exclude, &filter).await?;
+        let (count, total_size) = ops::stream_find_matches(
+            &pool,
+            scan_id,
+            &cli.pattern,
+            cli.insensitive,
+            &cli.exclude,
+            &filter,
+        )
+        .await?;
 
         if cli.size {
             println!("\n{} matches, {}", count, ops::format_size(total_size));

--- a/cmd/etp-find/src/main.rs
+++ b/cmd/etp-find/src/main.rs
@@ -71,8 +71,6 @@ struct Cli {
 async fn run(cli: Cli) -> Result<()> {
     let config = etp_lib::config::RuntimeConfig::load_or_default();
 
-    // Validate the regex once up front so we fail fast on bad syntax; SQLite
-    // will also refuse bad regex at query time, but this gives a cleaner error.
     ops::compile_pattern(&cli.pattern, cli.insensitive)?;
 
     // Resolve nicknames on -R/--root and/or --db.

--- a/cmd/etp-tree/src/main.rs
+++ b/cmd/etp-tree/src/main.rs
@@ -110,11 +110,12 @@ async fn run(cli: Cli) -> Result<()> {
     );
 
     if let Some(ref find_pattern) = cli.find {
-        let pattern = ops::compile_pattern(find_pattern, cli.insensitive)?;
+        ops::compile_pattern(find_pattern, cli.insensitive)?;
         let matches = ops::collect_find_matches(
             &ctx.pool,
             Some(ctx.scan_id),
-            &pattern,
+            find_pattern,
+            cli.insensitive,
             &cli.exclude,
             &filter,
         )

--- a/crates/etp-lib/Cargo.toml
+++ b/crates/etp-lib/Cargo.toml
@@ -24,7 +24,7 @@ regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
-sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "migrate"] }
+sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "migrate", "regexp"] }
 tokio = { version = "1", features = ["rt", "macros"] }
 etcetera = "0.11"
 walkdir = "2"

--- a/crates/etp-lib/src/db/dao.rs
+++ b/crates/etp-lib/src/db/dao.rs
@@ -505,6 +505,115 @@ pub fn stream_all_files(
     })
 }
 
+/// How to match the reconstructed full path when narrowing rows at the SQL
+/// layer. Both variants push filtering into SQLite so Rust only sees rows
+/// that already passed the pattern test.
+pub enum FindMatchOp {
+    /// SQL `LIKE pattern ESCAPE '\\'`. SQLite's built-in `LIKE` is ASCII
+    /// case-insensitive; the caller can re-verify in Rust to enforce
+    /// case-sensitive behavior.
+    Like(String),
+    /// SQL `REGEXP pattern` — uses the `regex` crate via sqlx's REGEXP UDF,
+    /// registered per-connection by `with_regexp()`.
+    Regexp(String),
+}
+
+// The 4 query variants (scan_id × match op) are defined as `&'static str`
+// consts so the streaming API can hand sqlx a `&'static str` without
+// per-call leaks or owned-string gymnastics. All four share the SELECT and
+// JOIN shape; only the WHERE clause differs.
+const FIND_LIKE_ALL: &str = "SELECT s.root_path, d.path, f.filename, f.size, f.ctime, f.mtime
+     FROM files f
+     JOIN directories d ON f.dir_id = d.id
+     JOIN scans s ON d.scan_id = s.id
+     WHERE (s.root_path || CASE WHEN d.path = '' THEN '' ELSE '/' || d.path END || '/' || f.filename) LIKE ? ESCAPE '\\'";
+const FIND_LIKE_SCAN: &str = "SELECT s.root_path, d.path, f.filename, f.size, f.ctime, f.mtime
+     FROM files f
+     JOIN directories d ON f.dir_id = d.id
+     JOIN scans s ON d.scan_id = s.id
+     WHERE d.scan_id = ?
+       AND (s.root_path || CASE WHEN d.path = '' THEN '' ELSE '/' || d.path END || '/' || f.filename) LIKE ? ESCAPE '\\'";
+const FIND_REGEXP_ALL: &str = "SELECT s.root_path, d.path, f.filename, f.size, f.ctime, f.mtime
+     FROM files f
+     JOIN directories d ON f.dir_id = d.id
+     JOIN scans s ON d.scan_id = s.id
+     WHERE (s.root_path || CASE WHEN d.path = '' THEN '' ELSE '/' || d.path END || '/' || f.filename) REGEXP ?";
+const FIND_REGEXP_SCAN: &str = "SELECT s.root_path, d.path, f.filename, f.size, f.ctime, f.mtime
+     FROM files f
+     JOIN directories d ON f.dir_id = d.id
+     JOIN scans s ON d.scan_id = s.id
+     WHERE d.scan_id = ?
+       AND (s.root_path || CASE WHEN d.path = '' THEN '' ELSE '/' || d.path END || '/' || f.filename) REGEXP ?";
+
+fn find_query_str(op: &FindMatchOp, has_scan_id: bool) -> &'static str {
+    match (op, has_scan_id) {
+        (FindMatchOp::Like(_), true) => FIND_LIKE_SCAN,
+        (FindMatchOp::Like(_), false) => FIND_LIKE_ALL,
+        (FindMatchOp::Regexp(_), true) => FIND_REGEXP_SCAN,
+        (FindMatchOp::Regexp(_), false) => FIND_REGEXP_ALL,
+    }
+}
+
+fn find_pattern(op: &FindMatchOp) -> &str {
+    match op {
+        FindMatchOp::Like(p) | FindMatchOp::Regexp(p) => p.as_str(),
+    }
+}
+
+/// List files matching a pattern pushed down to SQL. `scan_id: None` searches
+/// all scans. Returns full `FileRecord`s exactly like `list_files`.
+pub async fn list_files_matching(
+    pool: &SqlitePool,
+    scan_id: Option<i64>,
+    op: &FindMatchOp,
+) -> Result<Vec<FileRecord>, sqlx::Error> {
+    let query = find_query_str(op, scan_id.is_some());
+    let mut q = sqlx::query_as::<_, (String, String, String, i64, i64, i64)>(query);
+    if let Some(id) = scan_id {
+        q = q.bind(id);
+    }
+    q = q.bind(find_pattern(op));
+    let rows = q.fetch_all(pool).await?;
+    Ok(rows
+        .into_iter()
+        .map(|(root, dir_path, filename, size, ctime, mtime)| {
+            let full_path = if dir_path.is_empty() {
+                root
+            } else {
+                format!("{root}/{dir_path}")
+            };
+            FileRecord {
+                dir_path: full_path,
+                filename,
+                size: size as u64,
+                ctime,
+                mtime,
+            }
+        })
+        .collect())
+}
+
+/// Stream files matching a pattern pushed down to SQL. `scan_id: None`
+/// streams across all scans.
+pub fn stream_files_matching<'a>(
+    pool: &'a SqlitePool,
+    scan_id: Option<i64>,
+    op: &FindMatchOp,
+) -> Pin<Box<dyn Stream<Item = Result<FileRecord, sqlx::Error>> + Send + 'a>> {
+    let query = find_query_str(op, scan_id.is_some());
+    let pattern = match op {
+        FindMatchOp::Like(p) | FindMatchOp::Regexp(p) => p.clone(),
+    };
+    let mut q = sqlx::query_as::<_, (String, String, String, i64, i64, i64)>(query);
+    if let Some(id) = scan_id {
+        q = q.bind(id);
+    }
+    let raw = q.bind(pattern).fetch(pool);
+    Box::pin(MapStream {
+        inner: Box::pin(raw),
+    })
+}
+
 /// Get the total size of all files in a scan.
 pub async fn total_size(pool: &SqlitePool, scan_id: i64) -> Result<u64, sqlx::Error> {
     let row: (i64,) = sqlx::query_as(

--- a/crates/etp-lib/src/db/dao.rs
+++ b/crates/etp-lib/src/db/dao.rs
@@ -505,10 +505,16 @@ pub fn stream_all_files(
     })
 }
 
-// Two query variants (scan_id vs no scan_id) are `&'static str` consts so the
-// streaming API can hand sqlx a static pointer without per-call gymnastics.
-// Both push the match into SQLite via the REGEXP UDF registered by
-// `with_regexp()`. Callers handle case folding by prefixing `(?i)` as needed.
+// Query variants differ on two axes — scan-id filter and system-file filter —
+// so there are four `&'static str` consts. The streaming API needs a static
+// pointer without per-call string allocation. Every variant pushes the user
+// match into SQLite via the REGEXP UDF registered by `with_regexp()`;
+// callers handle case folding by prefixing `(?i)` as needed.
+//
+// The `*_NO_SYS` variants add `AND NOT (<full_path>) REGEXP ?` so system
+// files (@eaDir, .etp.db, etc.) are discarded at the B-tree layer rather
+// than crossing into Rust. SQLite short-circuits AND chains, so rows that
+// don't match the user pattern never hit the system regex.
 const FIND_REGEXP_ALL: &str = "SELECT s.root_path, d.path, f.filename, f.size, f.ctime, f.mtime
      FROM files f
      JOIN directories d ON f.dir_id = d.id
@@ -520,26 +526,51 @@ const FIND_REGEXP_SCAN: &str = "SELECT s.root_path, d.path, f.filename, f.size, 
      JOIN scans s ON d.scan_id = s.id
      WHERE d.scan_id = ?
        AND (s.root_path || CASE WHEN d.path = '' THEN '' ELSE '/' || d.path END || '/' || f.filename) REGEXP ?";
+const FIND_REGEXP_ALL_NO_SYS: &str = "SELECT s.root_path, d.path, f.filename, f.size, f.ctime, f.mtime
+     FROM files f
+     JOIN directories d ON f.dir_id = d.id
+     JOIN scans s ON d.scan_id = s.id
+     WHERE (s.root_path || CASE WHEN d.path = '' THEN '' ELSE '/' || d.path END || '/' || f.filename) REGEXP ?
+       AND NOT ((s.root_path || CASE WHEN d.path = '' THEN '' ELSE '/' || d.path END || '/' || f.filename) REGEXP ?)";
+const FIND_REGEXP_SCAN_NO_SYS: &str = "SELECT s.root_path, d.path, f.filename, f.size, f.ctime, f.mtime
+     FROM files f
+     JOIN directories d ON f.dir_id = d.id
+     JOIN scans s ON d.scan_id = s.id
+     WHERE d.scan_id = ?
+       AND (s.root_path || CASE WHEN d.path = '' THEN '' ELSE '/' || d.path END || '/' || f.filename) REGEXP ?
+       AND NOT ((s.root_path || CASE WHEN d.path = '' THEN '' ELSE '/' || d.path END || '/' || f.filename) REGEXP ?)";
 
-/// List files whose reconstructed full path matches `pattern` (a regex). Pass
-/// `scan_id: Some(id)` to search a single scan, or `None` to search all
-/// scans. Case sensitivity is controlled by the pattern itself — callers that
-/// want case-insensitive matching should prefix `(?i)`.
+fn find_query_str(has_scan_id: bool, has_system_re: bool) -> &'static str {
+    match (has_scan_id, has_system_re) {
+        (true, true) => FIND_REGEXP_SCAN_NO_SYS,
+        (true, false) => FIND_REGEXP_SCAN,
+        (false, true) => FIND_REGEXP_ALL_NO_SYS,
+        (false, false) => FIND_REGEXP_ALL,
+    }
+}
+
+/// List files whose reconstructed full path matches `pattern` (a regex).
+///
+/// - `scan_id: Some(id)` searches a single scan; `None` searches all scans.
+/// - `exclude_system_re: Some(r)` adds `AND NOT path REGEXP r` to the WHERE
+///   clause, so system files are filtered out at the SQL layer.
+/// - Case sensitivity is controlled by the pattern itself — callers that
+///   want case-insensitive matching should prefix `(?i)`.
 pub async fn list_files_matching(
     pool: &SqlitePool,
     scan_id: Option<i64>,
     pattern: &str,
+    exclude_system_re: Option<&str>,
 ) -> Result<Vec<FileRecord>, sqlx::Error> {
-    let query = if scan_id.is_some() {
-        FIND_REGEXP_SCAN
-    } else {
-        FIND_REGEXP_ALL
-    };
+    let query = find_query_str(scan_id.is_some(), exclude_system_re.is_some());
     let mut q = sqlx::query_as::<_, (String, String, String, i64, i64, i64)>(query);
     if let Some(id) = scan_id {
         q = q.bind(id);
     }
     q = q.bind(pattern);
+    if let Some(sys) = exclude_system_re {
+        q = q.bind(sys);
+    }
     let rows = q.fetch_all(pool).await?;
     Ok(rows
         .into_iter()
@@ -561,23 +592,23 @@ pub async fn list_files_matching(
 }
 
 /// Stream files whose reconstructed full path matches `pattern` (a regex).
-/// `scan_id: None` streams across all scans. See [`list_files_matching`] for
-/// case-sensitivity notes.
+/// See [`list_files_matching`] for parameter notes.
 pub fn stream_files_matching<'a>(
     pool: &'a SqlitePool,
     scan_id: Option<i64>,
     pattern: &str,
+    exclude_system_re: Option<&str>,
 ) -> Pin<Box<dyn Stream<Item = Result<FileRecord, sqlx::Error>> + Send + 'a>> {
-    let query = if scan_id.is_some() {
-        FIND_REGEXP_SCAN
-    } else {
-        FIND_REGEXP_ALL
-    };
+    let query = find_query_str(scan_id.is_some(), exclude_system_re.is_some());
     let mut q = sqlx::query_as::<_, (String, String, String, i64, i64, i64)>(query);
     if let Some(id) = scan_id {
         q = q.bind(id);
     }
-    let raw = q.bind(pattern.to_string()).fetch(pool);
+    q = q.bind(pattern.to_string());
+    if let Some(sys) = exclude_system_re {
+        q = q.bind(sys.to_string());
+    }
+    let raw = q.fetch(pool);
     Box::pin(MapStream {
         inner: Box::pin(raw),
     })

--- a/crates/etp-lib/src/db/dao.rs
+++ b/crates/etp-lib/src/db/dao.rs
@@ -1084,7 +1084,7 @@ pub async fn count_files_by_extension(
     }
 
     let mut result: Vec<(String, i64)> = counts.into_iter().collect();
-    result.sort_by(|a, b| b.1.cmp(&a.1));
+    result.sort_by_key(|r| std::cmp::Reverse(r.1));
     Ok(result)
 }
 

--- a/crates/etp-lib/src/db/dao.rs
+++ b/crates/etp-lib/src/db/dao.rs
@@ -368,7 +368,7 @@ pub async fn remove_stale_directories(
     tracing::instrument(name = "list_files", skip_all)
 )]
 pub async fn list_files(pool: &SqlitePool, scan_id: i64) -> Result<Vec<FileRecord>, sqlx::Error> {
-    let rows: Vec<(String, String, String, i64, i64, i64)> = sqlx::query_as(
+    let rows: Vec<RawRow> = sqlx::query_as(
         "SELECT s.root_path, d.path, f.filename, f.size, f.ctime, f.mtime
          FROM files f
          JOIN directories d ON f.dir_id = d.id
@@ -379,23 +379,7 @@ pub async fn list_files(pool: &SqlitePool, scan_id: i64) -> Result<Vec<FileRecor
     .fetch_all(pool)
     .await?;
 
-    Ok(rows
-        .into_iter()
-        .map(|(root, dir_path, filename, size, ctime, mtime)| {
-            let full_path = if dir_path.is_empty() {
-                root
-            } else {
-                format!("{}/{}", root, dir_path)
-            };
-            FileRecord {
-                dir_path: full_path,
-                filename,
-                size: size as u64,
-                ctime,
-                mtime,
-            }
-        })
-        .collect())
+    Ok(rows.into_iter().map(row_to_file_record).collect())
 }
 
 /// Stream all files for a scan, yielding `FileRecord` values one at a time
@@ -419,11 +403,24 @@ pub fn stream_files(
     })
 }
 
-type RawRowStream<'a> = Pin<
-    Box<
-        dyn Stream<Item = Result<(String, String, String, i64, i64, i64), sqlx::Error>> + Send + 'a,
-    >,
->;
+type RawRow = (String, String, String, i64, i64, i64);
+type RawRowStream<'a> = Pin<Box<dyn Stream<Item = Result<RawRow, sqlx::Error>> + Send + 'a>>;
+
+fn row_to_file_record(row: RawRow) -> FileRecord {
+    let (root, dir_path, filename, size, ctime, mtime) = row;
+    let full_path = if dir_path.is_empty() {
+        root
+    } else {
+        format!("{root}/{dir_path}")
+    };
+    FileRecord {
+        dir_path: full_path,
+        filename,
+        size: size as u64,
+        ctime,
+        mtime,
+    }
+}
 
 /// Adapter that maps raw query rows to `FileRecord`.
 struct MapStream<'a> {
@@ -437,30 +434,16 @@ impl Stream for MapStream<'_> {
         mut self: Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Self::Item>> {
-        self.inner.as_mut().poll_next(cx).map(|opt| {
-            opt.map(|res| {
-                res.map(|(root, dir_path, filename, size, ctime, mtime)| {
-                    let full_path = if dir_path.is_empty() {
-                        root
-                    } else {
-                        format!("{}/{}", root, dir_path)
-                    };
-                    FileRecord {
-                        dir_path: full_path,
-                        filename,
-                        size: size as u64,
-                        ctime,
-                        mtime,
-                    }
-                })
-            })
-        })
+        self.inner
+            .as_mut()
+            .poll_next(cx)
+            .map(|opt| opt.map(|res| res.map(row_to_file_record)))
     }
 }
 
 /// List all files across all scans. Same as `list_files` but without scan filter.
 pub async fn list_all_files(pool: &SqlitePool) -> Result<Vec<FileRecord>, sqlx::Error> {
-    let rows: Vec<(String, String, String, i64, i64, i64)> = sqlx::query_as(
+    let rows: Vec<RawRow> = sqlx::query_as(
         "SELECT s.root_path, d.path, f.filename, f.size, f.ctime, f.mtime
          FROM files f
          JOIN directories d ON f.dir_id = d.id
@@ -469,23 +452,7 @@ pub async fn list_all_files(pool: &SqlitePool) -> Result<Vec<FileRecord>, sqlx::
     .fetch_all(pool)
     .await?;
 
-    Ok(rows
-        .into_iter()
-        .map(|(root, dir_path, filename, size, ctime, mtime)| {
-            let full_path = if dir_path.is_empty() {
-                root
-            } else {
-                format!("{}/{}", root, dir_path)
-            };
-            FileRecord {
-                dir_path: full_path,
-                filename,
-                size: size as u64,
-                ctime,
-                mtime,
-            }
-        })
-        .collect())
+    Ok(rows.into_iter().map(row_to_file_record).collect())
 }
 
 /// Stream all files across all scans. Same as `stream_files` but without scan filter.
@@ -549,6 +516,27 @@ fn find_query_str(has_scan_id: bool, has_system_re: bool) -> &'static str {
     }
 }
 
+/// Build the SQL query + bind the user pattern, scan id, and system regex
+/// for the `list_files_matching` / `stream_files_matching` call path. Bind
+/// values are owned so the returned query is not tied to caller lifetimes —
+/// important for `stream_files_matching`, which must outlive its inputs.
+fn bind_find_query(
+    scan_id: Option<i64>,
+    pattern: &str,
+    exclude_system_re: Option<&str>,
+) -> sqlx::query::QueryAs<'static, sqlx::Sqlite, RawRow, sqlx::sqlite::SqliteArguments<'static>> {
+    let query = find_query_str(scan_id.is_some(), exclude_system_re.is_some());
+    let mut q = sqlx::query_as::<_, RawRow>(query);
+    if let Some(id) = scan_id {
+        q = q.bind(id);
+    }
+    q = q.bind(pattern.to_string());
+    if let Some(sys) = exclude_system_re {
+        q = q.bind(sys.to_string());
+    }
+    q
+}
+
 /// List files whose reconstructed full path matches `pattern` (a regex).
 ///
 /// - `scan_id: Some(id)` searches a single scan; `None` searches all scans.
@@ -562,33 +550,10 @@ pub async fn list_files_matching(
     pattern: &str,
     exclude_system_re: Option<&str>,
 ) -> Result<Vec<FileRecord>, sqlx::Error> {
-    let query = find_query_str(scan_id.is_some(), exclude_system_re.is_some());
-    let mut q = sqlx::query_as::<_, (String, String, String, i64, i64, i64)>(query);
-    if let Some(id) = scan_id {
-        q = q.bind(id);
-    }
-    q = q.bind(pattern);
-    if let Some(sys) = exclude_system_re {
-        q = q.bind(sys);
-    }
-    let rows = q.fetch_all(pool).await?;
-    Ok(rows
-        .into_iter()
-        .map(|(root, dir_path, filename, size, ctime, mtime)| {
-            let full_path = if dir_path.is_empty() {
-                root
-            } else {
-                format!("{root}/{dir_path}")
-            };
-            FileRecord {
-                dir_path: full_path,
-                filename,
-                size: size as u64,
-                ctime,
-                mtime,
-            }
-        })
-        .collect())
+    let rows = bind_find_query(scan_id, pattern, exclude_system_re)
+        .fetch_all(pool)
+        .await?;
+    Ok(rows.into_iter().map(row_to_file_record).collect())
 }
 
 /// Stream files whose reconstructed full path matches `pattern` (a regex).
@@ -599,16 +564,7 @@ pub fn stream_files_matching<'a>(
     pattern: &str,
     exclude_system_re: Option<&str>,
 ) -> Pin<Box<dyn Stream<Item = Result<FileRecord, sqlx::Error>> + Send + 'a>> {
-    let query = find_query_str(scan_id.is_some(), exclude_system_re.is_some());
-    let mut q = sqlx::query_as::<_, (String, String, String, i64, i64, i64)>(query);
-    if let Some(id) = scan_id {
-        q = q.bind(id);
-    }
-    q = q.bind(pattern.to_string());
-    if let Some(sys) = exclude_system_re {
-        q = q.bind(sys.to_string());
-    }
-    let raw = q.fetch(pool);
+    let raw = bind_find_query(scan_id, pattern, exclude_system_re).fetch(pool);
     Box::pin(MapStream {
         inner: Box::pin(raw),
     })

--- a/crates/etp-lib/src/db/dao.rs
+++ b/crates/etp-lib/src/db/dao.rs
@@ -505,34 +505,10 @@ pub fn stream_all_files(
     })
 }
 
-/// How to match the reconstructed full path when narrowing rows at the SQL
-/// layer. Both variants push filtering into SQLite so Rust only sees rows
-/// that already passed the pattern test.
-pub enum FindMatchOp {
-    /// SQL `LIKE pattern ESCAPE '\\'`. SQLite's built-in `LIKE` is ASCII
-    /// case-insensitive; the caller can re-verify in Rust to enforce
-    /// case-sensitive behavior.
-    Like(String),
-    /// SQL `REGEXP pattern` — uses the `regex` crate via sqlx's REGEXP UDF,
-    /// registered per-connection by `with_regexp()`.
-    Regexp(String),
-}
-
-// The 4 query variants (scan_id × match op) are defined as `&'static str`
-// consts so the streaming API can hand sqlx a `&'static str` without
-// per-call leaks or owned-string gymnastics. All four share the SELECT and
-// JOIN shape; only the WHERE clause differs.
-const FIND_LIKE_ALL: &str = "SELECT s.root_path, d.path, f.filename, f.size, f.ctime, f.mtime
-     FROM files f
-     JOIN directories d ON f.dir_id = d.id
-     JOIN scans s ON d.scan_id = s.id
-     WHERE (s.root_path || CASE WHEN d.path = '' THEN '' ELSE '/' || d.path END || '/' || f.filename) LIKE ? ESCAPE '\\'";
-const FIND_LIKE_SCAN: &str = "SELECT s.root_path, d.path, f.filename, f.size, f.ctime, f.mtime
-     FROM files f
-     JOIN directories d ON f.dir_id = d.id
-     JOIN scans s ON d.scan_id = s.id
-     WHERE d.scan_id = ?
-       AND (s.root_path || CASE WHEN d.path = '' THEN '' ELSE '/' || d.path END || '/' || f.filename) LIKE ? ESCAPE '\\'";
+// Two query variants (scan_id vs no scan_id) are `&'static str` consts so the
+// streaming API can hand sqlx a static pointer without per-call gymnastics.
+// Both push the match into SQLite via the REGEXP UDF registered by
+// `with_regexp()`. Callers handle case folding by prefixing `(?i)` as needed.
 const FIND_REGEXP_ALL: &str = "SELECT s.root_path, d.path, f.filename, f.size, f.ctime, f.mtime
      FROM files f
      JOIN directories d ON f.dir_id = d.id
@@ -545,34 +521,25 @@ const FIND_REGEXP_SCAN: &str = "SELECT s.root_path, d.path, f.filename, f.size, 
      WHERE d.scan_id = ?
        AND (s.root_path || CASE WHEN d.path = '' THEN '' ELSE '/' || d.path END || '/' || f.filename) REGEXP ?";
 
-fn find_query_str(op: &FindMatchOp, has_scan_id: bool) -> &'static str {
-    match (op, has_scan_id) {
-        (FindMatchOp::Like(_), true) => FIND_LIKE_SCAN,
-        (FindMatchOp::Like(_), false) => FIND_LIKE_ALL,
-        (FindMatchOp::Regexp(_), true) => FIND_REGEXP_SCAN,
-        (FindMatchOp::Regexp(_), false) => FIND_REGEXP_ALL,
-    }
-}
-
-fn find_pattern(op: &FindMatchOp) -> &str {
-    match op {
-        FindMatchOp::Like(p) | FindMatchOp::Regexp(p) => p.as_str(),
-    }
-}
-
-/// List files matching a pattern pushed down to SQL. `scan_id: None` searches
-/// all scans. Returns full `FileRecord`s exactly like `list_files`.
+/// List files whose reconstructed full path matches `pattern` (a regex). Pass
+/// `scan_id: Some(id)` to search a single scan, or `None` to search all
+/// scans. Case sensitivity is controlled by the pattern itself — callers that
+/// want case-insensitive matching should prefix `(?i)`.
 pub async fn list_files_matching(
     pool: &SqlitePool,
     scan_id: Option<i64>,
-    op: &FindMatchOp,
+    pattern: &str,
 ) -> Result<Vec<FileRecord>, sqlx::Error> {
-    let query = find_query_str(op, scan_id.is_some());
+    let query = if scan_id.is_some() {
+        FIND_REGEXP_SCAN
+    } else {
+        FIND_REGEXP_ALL
+    };
     let mut q = sqlx::query_as::<_, (String, String, String, i64, i64, i64)>(query);
     if let Some(id) = scan_id {
         q = q.bind(id);
     }
-    q = q.bind(find_pattern(op));
+    q = q.bind(pattern);
     let rows = q.fetch_all(pool).await?;
     Ok(rows
         .into_iter()
@@ -593,22 +560,24 @@ pub async fn list_files_matching(
         .collect())
 }
 
-/// Stream files matching a pattern pushed down to SQL. `scan_id: None`
-/// streams across all scans.
+/// Stream files whose reconstructed full path matches `pattern` (a regex).
+/// `scan_id: None` streams across all scans. See [`list_files_matching`] for
+/// case-sensitivity notes.
 pub fn stream_files_matching<'a>(
     pool: &'a SqlitePool,
     scan_id: Option<i64>,
-    op: &FindMatchOp,
+    pattern: &str,
 ) -> Pin<Box<dyn Stream<Item = Result<FileRecord, sqlx::Error>> + Send + 'a>> {
-    let query = find_query_str(op, scan_id.is_some());
-    let pattern = match op {
-        FindMatchOp::Like(p) | FindMatchOp::Regexp(p) => p.clone(),
+    let query = if scan_id.is_some() {
+        FIND_REGEXP_SCAN
+    } else {
+        FIND_REGEXP_ALL
     };
     let mut q = sqlx::query_as::<_, (String, String, String, i64, i64, i64)>(query);
     if let Some(id) = scan_id {
         q = q.bind(id);
     }
-    let raw = q.bind(pattern).fetch(pool);
+    let raw = q.bind(pattern.to_string()).fetch(pool);
     Box::pin(MapStream {
         inner: Box::pin(raw),
     })

--- a/crates/etp-lib/src/db/mod.rs
+++ b/crates/etp-lib/src/db/mod.rs
@@ -28,7 +28,8 @@ pub async fn open_db(path: &Path, verbose: bool) -> Result<SqlitePool, sqlx::Err
         .synchronous(sqlx::sqlite::SqliteSynchronous::Normal)
         .foreign_keys(true)
         .pragma("cache_size", "-64000") // 64 MiB page cache (negative = KiB)
-        .pragma("temp_store", "MEMORY"); // temp tables/indexes in memory
+        .pragma("temp_store", "MEMORY") // temp tables/indexes in memory
+        .with_regexp(); // enable REGEXP operator backed by the regex crate
     let pool = SqlitePoolOptions::new()
         .max_connections(1)
         .connect_with(options)
@@ -57,7 +58,8 @@ pub async fn close_db(pool: SqlitePool) {
 pub async fn open_memory() -> Result<SqlitePool, sqlx::Error> {
     let options = SqliteConnectOptions::from_str("sqlite::memory:")?
         .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal)
-        .foreign_keys(true);
+        .foreign_keys(true)
+        .with_regexp();
     let pool = SqlitePoolOptions::new()
         .max_connections(1)
         .connect_with(options)

--- a/crates/etp-lib/src/finder.rs
+++ b/crates/etp-lib/src/finder.rs
@@ -1,81 +1,13 @@
-use crate::db::dao::FileRecord;
-use regex::Regex;
-
 /// A file that matched a regex pattern, with its full path pre-computed.
+///
+/// Produced by `ops::collect_find_matches` after the SQL layer has filtered
+/// down to matching rows. The regex evaluation itself runs inside SQLite via
+/// the REGEXP UDF registered by `db::open_db` / `db::open_memory` — see the
+/// "Search (etp-find)" section of `docs/DESIGN_NOTES.md`.
 #[derive(Debug, Clone)]
 pub struct FindMatch {
     pub full_path: String,
     pub size: u64,
     pub ctime: i64,
     pub mtime: i64,
-}
-
-/// Test whether a file record matches the pattern, returning a `FindMatch` if so.
-pub fn matches_pattern(record: &FileRecord, pattern: &Regex) -> Option<FindMatch> {
-    let full_path = format!("{}/{}", record.dir_path, record.filename);
-    if pattern.is_match(&full_path) {
-        Some(FindMatch {
-            full_path,
-            size: record.size,
-            ctime: record.ctime,
-            mtime: record.mtime,
-        })
-    } else {
-        None
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn make_record(dir_path: &str, filename: &str, size: u64) -> FileRecord {
-        FileRecord {
-            dir_path: dir_path.to_string(),
-            filename: filename.to_string(),
-            size,
-            ctime: 1000,
-            mtime: 2000,
-        }
-    }
-
-    #[test]
-    fn matches_filename() {
-        let re = Regex::new(r"\.txt$").unwrap();
-        let record = make_record("/data/sub", "notes.txt", 100);
-        let m = matches_pattern(&record, &re).unwrap();
-        assert_eq!(m.full_path, "/data/sub/notes.txt");
-        assert_eq!(m.size, 100);
-    }
-
-    #[test]
-    fn no_match() {
-        let re = Regex::new(r"\.txt$").unwrap();
-        let record = make_record("/data/sub", "image.png", 200);
-        assert!(matches_pattern(&record, &re).is_none());
-    }
-
-    #[test]
-    fn matches_root_level_file() {
-        let re = Regex::new(r"readme").unwrap();
-        let record = make_record("/volume1/music", "readme.md", 50);
-        let m = matches_pattern(&record, &re).unwrap();
-        assert_eq!(m.full_path, "/volume1/music/readme.md");
-    }
-
-    #[test]
-    fn matches_unicode_filename() {
-        let re = Regex::new(r"カタカナ").unwrap();
-        let record = make_record("/data", "カタカナ.flac", 1000);
-        let m = matches_pattern(&record, &re).unwrap();
-        assert_eq!(m.full_path, "/data/カタカナ.flac");
-    }
-
-    #[test]
-    fn matches_path_component() {
-        let re = Regex::new(r"/sub/").unwrap();
-        let record = make_record("/data/sub", "file.txt", 100);
-        let m = matches_pattern(&record, &re).unwrap();
-        assert_eq!(m.full_path, "/data/sub/file.txt");
-    }
 }

--- a/crates/etp-lib/src/ops.rs
+++ b/crates/etp-lib/src/ops.rs
@@ -81,6 +81,33 @@ pub fn compile_pattern(pattern: &str, case_insensitive: bool) -> anyhow::Result<
         .map_err(|e| anyhow::anyhow!("invalid regex '{}': {}", pattern, e))
 }
 
+/// Return true when the pattern contains no regex metacharacters, i.e. it's
+/// meant as a plain substring search.
+pub fn is_literal_pattern(pattern: &str) -> bool {
+    !pattern.chars().any(|c| {
+        matches!(
+            c,
+            '.' | '^' | '$' | '*' | '+' | '?' | '(' | ')' | '[' | ']' | '{' | '}' | '|' | '\\'
+        )
+    })
+}
+
+/// Escape a literal substring for use with SQL `LIKE ... ESCAPE '\\'`.
+/// `%` and `_` are LIKE wildcards; `\\` is the escape character we use.
+pub fn escape_like_pattern(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '\\' | '%' | '_' => {
+                out.push('\\');
+                out.push(c);
+            }
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
 /// Verify that a path is a directory.
 pub fn validate_directory(root: &Path) -> anyhow::Result<()> {
     if !root.is_dir() {
@@ -529,25 +556,40 @@ pub async fn render_du(pool: &SqlitePool, scan_id: i64, show_subs: bool) -> anyh
     Ok(())
 }
 
+/// Decide how to translate a user pattern + `-i` flag into SQL-level filtering.
+///
+/// `-i` always routes through the REGEXP UDF with `(?i)` prefixed so the
+/// regex crate does proper Unicode case folding. Without `-i`, literal
+/// substrings use SQL `LIKE` (cheap, pushed into SQLite) and regex patterns
+/// use REGEXP. The LIKE path is ASCII case-insensitive (SQLite default); the
+/// Rust-side post-check in `matches_pattern` re-verifies case-sensitive
+/// matching so user-facing behavior is still case-sensitive without `-i`.
+fn build_find_op(pattern: &str, insensitive: bool) -> dao::FindMatchOp {
+    if insensitive {
+        dao::FindMatchOp::Regexp(format!("(?i){pattern}"))
+    } else if is_literal_pattern(pattern) {
+        dao::FindMatchOp::Like(format!("%{}%", escape_like_pattern(pattern)))
+    } else {
+        dao::FindMatchOp::Regexp(pattern.to_string())
+    }
+}
+
 /// Stream files from DB, printing matching paths immediately. Returns (count, total_size).
 ///
 /// Pass `scan_id: Some(id)` to search a single scan, or `None` to search all scans.
 pub async fn stream_find_matches(
     pool: &SqlitePool,
     scan_id: Option<i64>,
-    pattern: &regex::Regex,
+    pattern: &str,
+    insensitive: bool,
     exclude: &[String],
     filter: &FilterConfig,
 ) -> anyhow::Result<(usize, u64)> {
-    use crate::finder;
     use futures_util::StreamExt;
 
-    let mut stream: std::pin::Pin<
-        Box<dyn futures_core::Stream<Item = Result<dao::FileRecord, sqlx::Error>> + Send + '_>,
-    > = match scan_id {
-        Some(id) => dao::stream_files(pool, id),
-        None => dao::stream_all_files(pool),
-    };
+    let op = build_find_op(pattern, insensitive);
+    let verify = matches!(op, dao::FindMatchOp::Like(_)).then(|| pattern.to_string());
+    let mut stream = dao::stream_files_matching(pool, scan_id, &op);
 
     let mut count = 0;
     let mut total_size = 0u64;
@@ -560,11 +602,15 @@ pub async fn stream_find_matches(
         if !filter.should_show(&record.dir_path, &record.filename) {
             continue;
         }
-        if let Some(m) = finder::matches_pattern(&record, pattern) {
-            println!("{}", m.full_path);
-            total_size += m.size;
-            count += 1;
+        let full_path = format!("{}/{}", record.dir_path, record.filename);
+        if let Some(ref needle) = verify
+            && !full_path.contains(needle.as_str())
+        {
+            continue;
         }
+        println!("{full_path}");
+        total_size += record.size;
+        count += 1;
     }
 
     Ok((count, total_size))
@@ -576,23 +622,35 @@ pub async fn stream_find_matches(
 pub async fn collect_find_matches(
     pool: &SqlitePool,
     scan_id: Option<i64>,
-    pattern: &regex::Regex,
+    pattern: &str,
+    insensitive: bool,
     exclude: &[String],
     filter: &FilterConfig,
 ) -> anyhow::Result<Vec<crate::finder::FindMatch>> {
-    use crate::finder;
-
-    let files = match scan_id {
-        Some(id) => dao::list_files(pool, id).await,
-        None => dao::list_all_files(pool).await,
-    }
-    .context("reading from database")?;
+    let op = build_find_op(pattern, insensitive);
+    let verify = matches!(op, dao::FindMatchOp::Like(_)).then(|| pattern.to_string());
+    let files = dao::list_files_matching(pool, scan_id, &op)
+        .await
+        .context("reading from database")?;
 
     Ok(files
-        .iter()
+        .into_iter()
         .filter(|record| !is_excluded_path(&record.dir_path, exclude))
         .filter(|record| filter.should_show(&record.dir_path, &record.filename))
-        .filter_map(|record| finder::matches_pattern(record, pattern))
+        .filter_map(|record| {
+            let full_path = format!("{}/{}", record.dir_path, record.filename);
+            if let Some(ref needle) = verify
+                && !full_path.contains(needle.as_str())
+            {
+                return None;
+            }
+            Some(crate::finder::FindMatch {
+                full_path,
+                size: record.size,
+                ctime: record.ctime,
+                mtime: record.mtime,
+            })
+        })
         .collect())
 }
 
@@ -679,6 +737,65 @@ mod tests {
     #[test]
     fn format_size_tib() {
         assert_eq!(format_size(1024 * 1024 * 1024 * 1024), "1.00 TiB");
+    }
+
+    #[test]
+    fn is_literal_pattern_plain_ascii() {
+        assert!(is_literal_pattern("swans"));
+        assert!(is_literal_pattern("Hello World"));
+        assert!(is_literal_pattern("path/to/file"));
+    }
+
+    #[test]
+    fn is_literal_pattern_unicode_is_literal() {
+        assert!(is_literal_pattern("日本語"));
+        assert!(is_literal_pattern("Ångström"));
+    }
+
+    #[test]
+    fn is_literal_pattern_catches_all_metachars() {
+        for m in [
+            ".", "^", "$", "*", "+", "?", "(", ")", "[", "]", "{", "}", "|", "\\",
+        ] {
+            let pat = format!("abc{m}def");
+            assert!(
+                !is_literal_pattern(&pat),
+                "metachar {m} not caught in {pat}"
+            );
+        }
+    }
+
+    #[test]
+    fn escape_like_pattern_escapes_wildcards() {
+        assert_eq!(escape_like_pattern("foo"), "foo");
+        assert_eq!(escape_like_pattern("50%"), r"50\%");
+        assert_eq!(escape_like_pattern("a_b"), r"a\_b");
+        assert_eq!(escape_like_pattern(r"a\b"), r"a\\b");
+        assert_eq!(escape_like_pattern(r"50%_\x"), r"50\%\_\\x");
+    }
+
+    #[test]
+    fn build_find_op_insensitive_always_regexp() {
+        let op = super::build_find_op("swans", true);
+        assert!(matches!(op, dao::FindMatchOp::Regexp(ref p) if p == "(?i)swans"));
+    }
+
+    #[test]
+    fn build_find_op_literal_case_sensitive_is_like() {
+        let op = super::build_find_op("swans", false);
+        assert!(matches!(op, dao::FindMatchOp::Like(ref p) if p == "%swans%"));
+    }
+
+    #[test]
+    fn build_find_op_regex_without_i_is_regexp() {
+        let op = super::build_find_op("sw.*ns", false);
+        assert!(matches!(op, dao::FindMatchOp::Regexp(ref p) if p == "sw.*ns"));
+    }
+
+    #[test]
+    fn build_find_op_like_escapes_wildcards() {
+        let op = super::build_find_op("50% off", false);
+        assert!(matches!(op, dao::FindMatchOp::Like(ref p) if p == r"%50\% off%"));
     }
 
     #[test]

--- a/crates/etp-lib/src/ops.rs
+++ b/crates/etp-lib/src/ops.rs
@@ -243,6 +243,23 @@ impl FilterConfig {
         }
         true
     }
+
+    /// Like [`should_show`](Self::should_show), but assumes the SQL layer has
+    /// already applied the system-file filter when `include_system_files` is
+    /// false, so the expensive `is_system_path` walk is skipped. Only the
+    /// filename is checked — for the system-file exemption from dotfile and
+    /// user-exclude rules — because a filename that made it past SQL filtering
+    /// is, by construction, not in a system-named directory.
+    pub fn should_show_post_sql(&self, filename: &str) -> bool {
+        let is_system = is_system_name(filename, &self.system_patterns);
+        if !self.show_hidden && !is_system && filename.starts_with('.') {
+            return false;
+        }
+        if !is_system && is_user_excluded_name(filename, &self.user_excludes) {
+            return false;
+        }
+        true
+    }
 }
 
 /// Parse glob ignore patterns, warning on and discarding invalid ones.
@@ -540,6 +557,27 @@ fn regexp_pattern(pattern: &str, insensitive: bool) -> String {
     }
 }
 
+/// Build a regex that matches any path containing a system-pattern component.
+/// Used as the RHS of `AND NOT full_path REGEXP ?` to push system-file
+/// exclusion into SQLite.
+///
+/// Returns `None` when there are no patterns, so the caller can pick the
+/// cheaper query variant without the extra REGEXP call per row.
+fn system_excludes_regex(patterns: &HashSet<String>) -> Option<String> {
+    if patterns.is_empty() {
+        return None;
+    }
+    // Sort for stable output — helps sqlx-sqlite's auxdata regex cache reuse
+    // the compiled pattern across queries within a session.
+    let mut ps: Vec<&String> = patterns.iter().collect();
+    ps.sort();
+    let alternation: Vec<String> = ps.iter().map(|p| regex::escape(p)).collect();
+    // (?:^|/) and (?:$|/) anchor the match to whole path components, so
+    // `@eaDir` matches `foo/@eaDir/bar` and `foo/@eaDir` but NOT
+    // `foo/@eaDirectory`.
+    Some(format!(r"(?:^|/)(?:{})(?:$|/)", alternation.join("|")))
+}
+
 /// Stream files from DB, printing matching paths immediately. Returns (count, total_size).
 ///
 /// Pass `scan_id: Some(id)` to search a single scan, or `None` to search all scans.
@@ -554,7 +592,10 @@ pub async fn stream_find_matches(
     use futures_util::StreamExt;
 
     let sql_pattern = regexp_pattern(pattern, insensitive);
-    let mut stream = dao::stream_files_matching(pool, scan_id, &sql_pattern);
+    let system_re = (!filter.include_system_files)
+        .then(|| system_excludes_regex(&filter.system_patterns))
+        .flatten();
+    let mut stream = dao::stream_files_matching(pool, scan_id, &sql_pattern, system_re.as_deref());
 
     let mut count = 0;
     let mut total_size = 0u64;
@@ -564,7 +605,10 @@ pub async fn stream_find_matches(
         if is_excluded_path(&record.dir_path, exclude) {
             continue;
         }
-        if !filter.should_show(&record.dir_path, &record.filename) {
+        // System files are already excluded at the SQL layer when
+        // include_system_files is false. Passing the forged filter here
+        // skips the redundant is_system_path walk over every path component.
+        if !filter.should_show_post_sql(&record.filename) {
             continue;
         }
         println!("{}/{}", record.dir_path, record.filename);
@@ -587,14 +631,17 @@ pub async fn collect_find_matches(
     filter: &FilterConfig,
 ) -> anyhow::Result<Vec<crate::finder::FindMatch>> {
     let sql_pattern = regexp_pattern(pattern, insensitive);
-    let files = dao::list_files_matching(pool, scan_id, &sql_pattern)
+    let system_re = (!filter.include_system_files)
+        .then(|| system_excludes_regex(&filter.system_patterns))
+        .flatten();
+    let files = dao::list_files_matching(pool, scan_id, &sql_pattern, system_re.as_deref())
         .await
         .context("reading from database")?;
 
     Ok(files
         .into_iter()
         .filter(|record| !is_excluded_path(&record.dir_path, exclude))
-        .filter(|record| filter.should_show(&record.dir_path, &record.filename))
+        .filter(|record| filter.should_show_post_sql(&record.filename))
         .map(|record| crate::finder::FindMatch {
             full_path: format!("{}/{}", record.dir_path, record.filename),
             size: record.size,
@@ -699,6 +746,43 @@ mod tests {
     fn regexp_pattern_prefixes_i_flag() {
         assert_eq!(super::regexp_pattern("swans", true), "(?i)swans");
         assert_eq!(super::regexp_pattern("Björk", true), "(?i)Björk");
+    }
+
+    #[test]
+    fn system_excludes_regex_empty_returns_none() {
+        assert_eq!(super::system_excludes_regex(&HashSet::new()), None);
+    }
+
+    #[test]
+    fn system_excludes_regex_escapes_metachars_and_anchors_components() {
+        let patterns: HashSet<String> = ["@eaDir", ".etp.db", "#recycle"]
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect();
+        let re = super::system_excludes_regex(&patterns).unwrap();
+        // Alternation is sorted; `regex::escape` conservatively escapes `.`,
+        // `#` (potential `x`-flag comment) and `@`-safe chars. Confirm that
+        // the resulting regex compiles and works — not the exact bytes.
+        let compiled = regex::Regex::new(&re).unwrap();
+        assert!(compiled.is_match("/@eaDir"));
+        assert!(compiled.is_match("/a/.etp.db"));
+        assert!(compiled.is_match("/a/#recycle/b"));
+        assert!(!compiled.is_match("/a/normal/b"));
+    }
+
+    #[test]
+    fn system_excludes_regex_matches_component_only() {
+        let patterns: HashSet<String> = ["@eaDir"].iter().map(|s| (*s).to_string()).collect();
+        let re_str = super::system_excludes_regex(&patterns).unwrap();
+        let re = regex::Regex::new(&re_str).unwrap();
+        // Component hits:
+        assert!(re.is_match("/a/b/@eaDir/c"));
+        assert!(re.is_match("/a/b/@eaDir"));
+        assert!(re.is_match("@eaDir/c"));
+        assert!(re.is_match("@eaDir"));
+        // Must NOT false-match a substring inside another name:
+        assert!(!re.is_match("/a/@eaDirectory/c"));
+        assert!(!re.is_match("/a/not@eaDir/c"));
     }
 
     #[test]

--- a/crates/etp-lib/src/ops.rs
+++ b/crates/etp-lib/src/ops.rs
@@ -81,33 +81,6 @@ pub fn compile_pattern(pattern: &str, case_insensitive: bool) -> anyhow::Result<
         .map_err(|e| anyhow::anyhow!("invalid regex '{}': {}", pattern, e))
 }
 
-/// Return true when the pattern contains no regex metacharacters, i.e. it's
-/// meant as a plain substring search.
-pub fn is_literal_pattern(pattern: &str) -> bool {
-    !pattern.chars().any(|c| {
-        matches!(
-            c,
-            '.' | '^' | '$' | '*' | '+' | '?' | '(' | ')' | '[' | ']' | '{' | '}' | '|' | '\\'
-        )
-    })
-}
-
-/// Escape a literal substring for use with SQL `LIKE ... ESCAPE '\\'`.
-/// `%` and `_` are LIKE wildcards; `\\` is the escape character we use.
-pub fn escape_like_pattern(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for c in s.chars() {
-        match c {
-            '\\' | '%' | '_' => {
-                out.push('\\');
-                out.push(c);
-            }
-            _ => out.push(c),
-        }
-    }
-    out
-}
-
 /// Verify that a path is a directory.
 pub fn validate_directory(root: &Path) -> anyhow::Result<()> {
     if !root.is_dir() {
@@ -556,21 +529,14 @@ pub async fn render_du(pool: &SqlitePool, scan_id: i64, show_subs: bool) -> anyh
     Ok(())
 }
 
-/// Decide how to translate a user pattern + `-i` flag into SQL-level filtering.
-///
-/// `-i` always routes through the REGEXP UDF with `(?i)` prefixed so the
-/// regex crate does proper Unicode case folding. Without `-i`, literal
-/// substrings use SQL `LIKE` (cheap, pushed into SQLite) and regex patterns
-/// use REGEXP. The LIKE path is ASCII case-insensitive (SQLite default); the
-/// Rust-side post-check in `matches_pattern` re-verifies case-sensitive
-/// matching so user-facing behavior is still case-sensitive without `-i`.
-fn build_find_op(pattern: &str, insensitive: bool) -> dao::FindMatchOp {
+/// Build the regex pattern handed to SQLite's REGEXP UDF. `-i` prefixes
+/// `(?i)` so the Rust `regex` crate applies Unicode simple case folding;
+/// otherwise the pattern is used as-is and matches case-sensitively.
+fn regexp_pattern(pattern: &str, insensitive: bool) -> String {
     if insensitive {
-        dao::FindMatchOp::Regexp(format!("(?i){pattern}"))
-    } else if is_literal_pattern(pattern) {
-        dao::FindMatchOp::Like(format!("%{}%", escape_like_pattern(pattern)))
+        format!("(?i){pattern}")
     } else {
-        dao::FindMatchOp::Regexp(pattern.to_string())
+        pattern.to_string()
     }
 }
 
@@ -587,9 +553,8 @@ pub async fn stream_find_matches(
 ) -> anyhow::Result<(usize, u64)> {
     use futures_util::StreamExt;
 
-    let op = build_find_op(pattern, insensitive);
-    let verify = matches!(op, dao::FindMatchOp::Like(_)).then(|| pattern.to_string());
-    let mut stream = dao::stream_files_matching(pool, scan_id, &op);
+    let sql_pattern = regexp_pattern(pattern, insensitive);
+    let mut stream = dao::stream_files_matching(pool, scan_id, &sql_pattern);
 
     let mut count = 0;
     let mut total_size = 0u64;
@@ -602,13 +567,7 @@ pub async fn stream_find_matches(
         if !filter.should_show(&record.dir_path, &record.filename) {
             continue;
         }
-        let full_path = format!("{}/{}", record.dir_path, record.filename);
-        if let Some(ref needle) = verify
-            && !full_path.contains(needle.as_str())
-        {
-            continue;
-        }
-        println!("{full_path}");
+        println!("{}/{}", record.dir_path, record.filename);
         total_size += record.size;
         count += 1;
     }
@@ -627,9 +586,8 @@ pub async fn collect_find_matches(
     exclude: &[String],
     filter: &FilterConfig,
 ) -> anyhow::Result<Vec<crate::finder::FindMatch>> {
-    let op = build_find_op(pattern, insensitive);
-    let verify = matches!(op, dao::FindMatchOp::Like(_)).then(|| pattern.to_string());
-    let files = dao::list_files_matching(pool, scan_id, &op)
+    let sql_pattern = regexp_pattern(pattern, insensitive);
+    let files = dao::list_files_matching(pool, scan_id, &sql_pattern)
         .await
         .context("reading from database")?;
 
@@ -637,19 +595,11 @@ pub async fn collect_find_matches(
         .into_iter()
         .filter(|record| !is_excluded_path(&record.dir_path, exclude))
         .filter(|record| filter.should_show(&record.dir_path, &record.filename))
-        .filter_map(|record| {
-            let full_path = format!("{}/{}", record.dir_path, record.filename);
-            if let Some(ref needle) = verify
-                && !full_path.contains(needle.as_str())
-            {
-                return None;
-            }
-            Some(crate::finder::FindMatch {
-                full_path,
-                size: record.size,
-                ctime: record.ctime,
-                mtime: record.mtime,
-            })
+        .map(|record| crate::finder::FindMatch {
+            full_path: format!("{}/{}", record.dir_path, record.filename),
+            size: record.size,
+            ctime: record.ctime,
+            mtime: record.mtime,
         })
         .collect())
 }
@@ -740,62 +690,15 @@ mod tests {
     }
 
     #[test]
-    fn is_literal_pattern_plain_ascii() {
-        assert!(is_literal_pattern("swans"));
-        assert!(is_literal_pattern("Hello World"));
-        assert!(is_literal_pattern("path/to/file"));
+    fn regexp_pattern_passes_through_without_i() {
+        assert_eq!(super::regexp_pattern("swans", false), "swans");
+        assert_eq!(super::regexp_pattern("sw.*ns", false), "sw.*ns");
     }
 
     #[test]
-    fn is_literal_pattern_unicode_is_literal() {
-        assert!(is_literal_pattern("日本語"));
-        assert!(is_literal_pattern("Ångström"));
-    }
-
-    #[test]
-    fn is_literal_pattern_catches_all_metachars() {
-        for m in [
-            ".", "^", "$", "*", "+", "?", "(", ")", "[", "]", "{", "}", "|", "\\",
-        ] {
-            let pat = format!("abc{m}def");
-            assert!(
-                !is_literal_pattern(&pat),
-                "metachar {m} not caught in {pat}"
-            );
-        }
-    }
-
-    #[test]
-    fn escape_like_pattern_escapes_wildcards() {
-        assert_eq!(escape_like_pattern("foo"), "foo");
-        assert_eq!(escape_like_pattern("50%"), r"50\%");
-        assert_eq!(escape_like_pattern("a_b"), r"a\_b");
-        assert_eq!(escape_like_pattern(r"a\b"), r"a\\b");
-        assert_eq!(escape_like_pattern(r"50%_\x"), r"50\%\_\\x");
-    }
-
-    #[test]
-    fn build_find_op_insensitive_always_regexp() {
-        let op = super::build_find_op("swans", true);
-        assert!(matches!(op, dao::FindMatchOp::Regexp(ref p) if p == "(?i)swans"));
-    }
-
-    #[test]
-    fn build_find_op_literal_case_sensitive_is_like() {
-        let op = super::build_find_op("swans", false);
-        assert!(matches!(op, dao::FindMatchOp::Like(ref p) if p == "%swans%"));
-    }
-
-    #[test]
-    fn build_find_op_regex_without_i_is_regexp() {
-        let op = super::build_find_op("sw.*ns", false);
-        assert!(matches!(op, dao::FindMatchOp::Regexp(ref p) if p == "sw.*ns"));
-    }
-
-    #[test]
-    fn build_find_op_like_escapes_wildcards() {
-        let op = super::build_find_op("50% off", false);
-        assert!(matches!(op, dao::FindMatchOp::Like(ref p) if p == r"%50\% off%"));
+    fn regexp_pattern_prefixes_i_flag() {
+        assert_eq!(super::regexp_pattern("swans", true), "(?i)swans");
+        assert_eq!(super::regexp_pattern("Björk", true), "(?i)Björk");
     }
 
     #[test]

--- a/crates/etp-lib/src/scanner.rs
+++ b/crates/etp-lib/src/scanner.rs
@@ -5,8 +5,26 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::os::unix::fs::MetadataExt;
 use std::path::Path;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use walkdir::WalkDir;
+
+/// Verbose progress cadence for long phases (walk, reconcile match loop).
+const PROGRESS_EVERY: Duration = Duration::from_secs(30);
+
+/// Log a completed phase when `verbose` is true. `detail` may be empty.
+fn log_phase(verbose: bool, name: &str, elapsed: Duration, detail: &str) {
+    if !verbose {
+        return;
+    }
+    if detail.is_empty() {
+        eprintln!("phase: {name} done in {:.2}s", elapsed.as_secs_f64());
+    } else {
+        eprintln!(
+            "phase: {name} done in {:.2}s — {detail}",
+            elapsed.as_secs_f64()
+        );
+    }
+}
 
 #[derive(Debug, thiserror::Error)]
 pub enum ScanError {
@@ -58,13 +76,12 @@ pub async fn scan_to_db(
     // Bulk-load all cached mtimes in one query instead of per-directory SELECTs.
     let phase = Instant::now();
     let cached_mtimes: HashMap<String, i64> = dao::all_directory_mtimes(pool, scan_id).await?;
-    if verbose {
-        eprintln!(
-            "phase: all_directory_mtimes done in {:.2}s — {} entries",
-            phase.elapsed().as_secs_f64(),
-            cached_mtimes.len(),
-        );
-    }
+    log_phase(
+        verbose,
+        "all_directory_mtimes",
+        phase.elapsed(),
+        &format!("{} entries", cached_mtimes.len()),
+    );
 
     // Walk without sorting — order doesn't matter for scanning (output reads
     // from DB with its own sort). Skipping sort avoids buffering + extra
@@ -74,7 +91,6 @@ pub async fn scan_to_db(
     const BATCH_SIZE: usize = 64;
     let walk_start = Instant::now();
     let mut last_progress = Instant::now();
-    const PROGRESS_EVERY: std::time::Duration = std::time::Duration::from_secs(30);
 
     for entry in WalkDir::new(root)
         .sort_by(|_, _| std::cmp::Ordering::Equal)
@@ -172,24 +188,21 @@ pub async fn scan_to_db(
         let phase = Instant::now();
         let removed = flush_pending(pool, scan_id, &mut pending).await?;
         all_removed.extend(removed);
-        if verbose {
-            eprintln!(
-                "phase: final flush_pending done in {:.2}s",
-                phase.elapsed().as_secs_f64()
-            );
-        }
+        log_phase(verbose, "final flush_pending", phase.elapsed(), "");
     }
 
-    if verbose {
-        eprintln!(
-            "phase: walk complete in {:.2}s — dirs_scanned={}, dirs_cached={}, removed_files_accum={}, seen_paths={}",
-            walk_start.elapsed().as_secs_f64(),
+    log_phase(
+        verbose,
+        "walk",
+        walk_start.elapsed(),
+        &format!(
+            "dirs_scanned={}, dirs_cached={}, removed_files_accum={}, seen_paths={}",
             stats.dirs_scanned,
             stats.dirs_cached,
             all_removed.len(),
             seen_paths.len(),
-        );
-    }
+        ),
+    );
 
     // If nothing was scanned, every directory matched its cached mtime —
     // the DB is already in sync and no directories can be stale.
@@ -200,27 +213,27 @@ pub async fn scan_to_db(
         (0, Vec::new())
     };
     stats.dirs_removed = dir_removed;
-    if verbose {
-        eprintln!(
-            "phase: remove_stale_directories done in {:.2}s — dir_removed={}, stale_orphans={}",
-            phase.elapsed().as_secs_f64(),
-            dir_removed,
-            stale_orphans.len(),
-        );
-    }
+    log_phase(
+        verbose,
+        "remove_stale_directories",
+        phase.elapsed(),
+        &format!(
+            "dir_removed={dir_removed}, stale_orphans={}",
+            stale_orphans.len()
+        ),
+    );
 
     // Move-tracking: match removed files against newly appeared files by
     // size, then verify with BLAKE3 hash. Matched files get their dir_id
     // and filename updated; unmatched files are deleted.
     let phase = Instant::now();
     let orphan_hashes = reconcile_moves(pool, root, &mut all_removed, verbose).await?;
-    if verbose {
-        eprintln!(
-            "phase: reconcile_moves done in {:.2}s — orphan_hashes={}",
-            phase.elapsed().as_secs_f64(),
-            orphan_hashes.len(),
-        );
-    }
+    log_phase(
+        verbose,
+        "reconcile_moves",
+        phase.elapsed(),
+        &format!("orphan_hashes={}", orphan_hashes.len()),
+    );
 
     // Clean up CAS blobs orphaned by unmatched deletions + stale dirs
     let phase = Instant::now();
@@ -230,22 +243,16 @@ pub async fn scan_to_db(
             blobs_removed += 1;
         }
     }
-    if verbose {
-        eprintln!(
-            "phase: cas blob cleanup done in {:.2}s — blobs_removed={}",
-            phase.elapsed().as_secs_f64(),
-            blobs_removed,
-        );
-    }
+    log_phase(
+        verbose,
+        "cas blob cleanup",
+        phase.elapsed(),
+        &format!("blobs_removed={blobs_removed}"),
+    );
 
     let phase = Instant::now();
     dao::finish_scan(pool, scan_id).await?;
-    if verbose {
-        eprintln!(
-            "phase: finish_scan done in {:.2}s",
-            phase.elapsed().as_secs_f64(),
-        );
-    }
+    log_phase(verbose, "finish_scan", phase.elapsed(), "");
 
     stats.elapsed_ms = start.elapsed().as_millis();
 
@@ -430,7 +437,7 @@ async fn reconcile_moves(
         };
         hashes_computed += 1;
 
-        if verbose && match_last_progress.elapsed() >= std::time::Duration::from_secs(30) {
+        if verbose && match_last_progress.elapsed() >= PROGRESS_EVERY {
             eprintln!(
                 "  reconcile: matching at {:.1}s — matched={}, hashes_computed={}",
                 match_start.elapsed().as_secs_f64(),

--- a/crates/etp-lib/src/scanner.rs
+++ b/crates/etp-lib/src/scanner.rs
@@ -56,7 +56,15 @@ pub async fn scan_to_db(
     let mut all_removed: Vec<RemovedFile> = Vec::new();
 
     // Bulk-load all cached mtimes in one query instead of per-directory SELECTs.
+    let phase = Instant::now();
     let cached_mtimes: HashMap<String, i64> = dao::all_directory_mtimes(pool, scan_id).await?;
+    if verbose {
+        eprintln!(
+            "phase: all_directory_mtimes done in {:.2}s — {} entries",
+            phase.elapsed().as_secs_f64(),
+            cached_mtimes.len(),
+        );
+    }
 
     // Walk without sorting — order doesn't matter for scanning (output reads
     // from DB with its own sort). Skipping sort avoids buffering + extra
@@ -64,6 +72,9 @@ pub async fn scan_to_db(
     // walkdir never descends into them.
     let mut pending: Vec<DirUpdate> = Vec::new();
     const BATCH_SIZE: usize = 64;
+    let walk_start = Instant::now();
+    let mut last_progress = Instant::now();
+    const PROGRESS_EVERY: std::time::Duration = std::time::Duration::from_secs(30);
 
     for entry in WalkDir::new(root)
         .sort_by(|_, _| std::cmp::Ordering::Equal)
@@ -142,34 +153,99 @@ pub async fn scan_to_db(
             let removed = flush_pending(pool, scan_id, &mut pending).await?;
             all_removed.extend(removed);
         }
+
+        if verbose && last_progress.elapsed() >= PROGRESS_EVERY {
+            eprintln!(
+                "progress: walking at {:.1}s — dirs_scanned={}, dirs_cached={}, seen_paths={}, removed_accum={}",
+                walk_start.elapsed().as_secs_f64(),
+                stats.dirs_scanned,
+                stats.dirs_cached,
+                seen_paths.len(),
+                all_removed.len(),
+            );
+            last_progress = Instant::now();
+        }
     }
 
     // Flush any remaining directories
     if !pending.is_empty() {
+        let phase = Instant::now();
         let removed = flush_pending(pool, scan_id, &mut pending).await?;
         all_removed.extend(removed);
+        if verbose {
+            eprintln!(
+                "phase: final flush_pending done in {:.2}s",
+                phase.elapsed().as_secs_f64()
+            );
+        }
+    }
+
+    if verbose {
+        eprintln!(
+            "phase: walk complete in {:.2}s — dirs_scanned={}, dirs_cached={}, removed_files_accum={}, seen_paths={}",
+            walk_start.elapsed().as_secs_f64(),
+            stats.dirs_scanned,
+            stats.dirs_cached,
+            all_removed.len(),
+            seen_paths.len(),
+        );
     }
 
     // If nothing was scanned, every directory matched its cached mtime —
     // the DB is already in sync and no directories can be stale.
+    let phase = Instant::now();
     let (dir_removed, stale_orphans) = if stats.dirs_scanned > 0 {
         dao::remove_stale_directories(pool, scan_id, &seen_paths).await?
     } else {
         (0, Vec::new())
     };
     stats.dirs_removed = dir_removed;
+    if verbose {
+        eprintln!(
+            "phase: remove_stale_directories done in {:.2}s — dir_removed={}, stale_orphans={}",
+            phase.elapsed().as_secs_f64(),
+            dir_removed,
+            stale_orphans.len(),
+        );
+    }
 
     // Move-tracking: match removed files against newly appeared files by
     // size, then verify with BLAKE3 hash. Matched files get their dir_id
     // and filename updated; unmatched files are deleted.
+    let phase = Instant::now();
     let orphan_hashes = reconcile_moves(pool, root, &mut all_removed, verbose).await?;
-
-    // Clean up CAS blobs orphaned by unmatched deletions + stale dirs
-    for hash in orphan_hashes.iter().chain(stale_orphans.iter()) {
-        let _ = cas::remove_blob(hash, cas_dir);
+    if verbose {
+        eprintln!(
+            "phase: reconcile_moves done in {:.2}s — orphan_hashes={}",
+            phase.elapsed().as_secs_f64(),
+            orphan_hashes.len(),
+        );
     }
 
+    // Clean up CAS blobs orphaned by unmatched deletions + stale dirs
+    let phase = Instant::now();
+    let mut blobs_removed = 0usize;
+    for hash in orphan_hashes.iter().chain(stale_orphans.iter()) {
+        if cas::remove_blob(hash, cas_dir).is_ok() {
+            blobs_removed += 1;
+        }
+    }
+    if verbose {
+        eprintln!(
+            "phase: cas blob cleanup done in {:.2}s — blobs_removed={}",
+            phase.elapsed().as_secs_f64(),
+            blobs_removed,
+        );
+    }
+
+    let phase = Instant::now();
     dao::finish_scan(pool, scan_id).await?;
+    if verbose {
+        eprintln!(
+            "phase: finish_scan done in {:.2}s",
+            phase.elapsed().as_secs_f64(),
+        );
+    }
 
     stats.elapsed_ms = start.elapsed().as_millis();
 
@@ -229,6 +305,10 @@ async fn reconcile_moves(
         return Ok(Vec::new());
     }
 
+    if verbose {
+        eprintln!("  reconcile: starting with {} removed files", removed.len());
+    }
+
     // Build a size → removed-files index
     let mut by_size: HashMap<u64, Vec<usize>> = HashMap::new();
     for (i, rf) in removed.iter().enumerate() {
@@ -245,6 +325,14 @@ async fn reconcile_moves(
 
     // Collect removed file IDs to exclude from candidates
     let removed_ids: HashSet<i64> = removed.iter().map(|rf| rf.file_id).collect();
+
+    if verbose {
+        eprintln!(
+            "  reconcile: {} unique sizes, {} removed_ids — building candidate query",
+            sizes.len(),
+            removed_ids.len()
+        );
+    }
 
     // Query files that match sizes of removed files. We filter out removed
     // file IDs to avoid matching a file against itself. We also exclude files
@@ -270,11 +358,20 @@ async fn reconcile_moves(
     for &s in &sizes {
         q = q.bind(s as i64);
     }
+    let phase = Instant::now();
     let candidates: Vec<(i64, String, String, i64, i64, i64, i64)> = q.fetch_all(pool).await?;
+    if verbose {
+        eprintln!(
+            "  reconcile: candidate query done in {:.2}s — {} candidates",
+            phase.elapsed().as_secs_f64(),
+            candidates.len()
+        );
+    }
 
     // Pre-fetch directory paths for removed files in one query (must happen
     // before we start the transaction, since pool has max_connections=1)
     let unique_dir_ids: HashSet<i64> = removed.iter().map(|rf| rf.dir_id).collect();
+    let phase = Instant::now();
     let dir_paths: HashMap<i64, String> = if unique_dir_ids.is_empty() {
         HashMap::new()
     } else {
@@ -290,6 +387,13 @@ async fn reconcile_moves(
         }
         q.fetch_all(pool).await?.into_iter().collect()
     };
+    if verbose {
+        eprintln!(
+            "  reconcile: dir_paths query done in {:.2}s — {} dirs",
+            phase.elapsed().as_secs_f64(),
+            dir_paths.len()
+        );
+    }
 
     // Build a size → candidates index to check uniqueness
     let mut candidates_by_size: HashMap<u64, Vec<usize>> = HashMap::new();
@@ -299,6 +403,9 @@ async fn reconcile_moves(
 
     let mut matched_removed: HashSet<usize> = HashSet::new();
     let mut matched_new: HashSet<i64> = HashSet::new();
+    let match_start = Instant::now();
+    let mut match_last_progress = Instant::now();
+    let mut hashes_computed = 0usize;
     let mut tx = pool.begin().await?;
 
     for (new_id, dir_path, new_filename, new_size, new_dir_id, new_mtime, new_ctime) in &candidates
@@ -321,6 +428,17 @@ async fn reconcile_moves(
             Some(h) => h,
             None => continue,
         };
+        hashes_computed += 1;
+
+        if verbose && match_last_progress.elapsed() >= std::time::Duration::from_secs(30) {
+            eprintln!(
+                "  reconcile: matching at {:.1}s — matched={}, hashes_computed={}",
+                match_start.elapsed().as_secs_f64(),
+                matched_new.len(),
+                hashes_computed
+            );
+            match_last_progress = Instant::now();
+        }
 
         for &idx in removed_indices {
             if matched_removed.contains(&idx) {
@@ -406,6 +524,15 @@ async fn reconcile_moves(
         }
     }
 
+    if verbose {
+        eprintln!(
+            "  reconcile: match loop done in {:.2}s — matched={}, hashes_computed={}",
+            match_start.elapsed().as_secs_f64(),
+            matched_new.len(),
+            hashes_computed
+        );
+    }
+
     // Delete unmatched removed files
     let unmatched: Vec<RemovedFile> = removed
         .iter()
@@ -414,8 +541,17 @@ async fn reconcile_moves(
         .map(|(_, rf)| rf.clone())
         .collect();
 
+    let phase = Instant::now();
     let orphans = dao::delete_unmatched_files(&mut tx, &unmatched).await?;
     tx.commit().await?;
+    if verbose {
+        eprintln!(
+            "  reconcile: delete_unmatched + commit done in {:.2}s — unmatched={}, orphans={}",
+            phase.elapsed().as_secs_f64(),
+            unmatched.len(),
+            orphans.len()
+        );
+    }
     Ok(orphans)
 }
 

--- a/crates/etp-lib/tests/find_sql_pushdown.rs
+++ b/crates/etp-lib/tests/find_sql_pushdown.rs
@@ -1,6 +1,41 @@
-//! Behavior tests for `-i` → REGEXP UDF, literal → LIKE, and regex → REGEXP
-//! in `collect_find_matches` / `stream_find_matches`. Exercises the real
-//! sqlx-sqlite REGEXP UDF registered by `with_regexp()`.
+//! Behavior tests for `etp-find`'s SQL-pushdown pattern matching.
+//!
+//! # Dispatch matrix
+//!
+//! Three strategies are dispatched by [`ops::collect_find_matches`] /
+//! [`ops::stream_find_matches`] based on `(pattern shape, -i)`:
+//!
+//! | pattern shape          | `-i`     | SQL op           | post-filter |
+//! | ---------------------- | -------- | ---------------- | ----------- |
+//! | literal (no metachars) | off      | `LIKE … ESCAPE`  | `contains`  |
+//! | literal (no metachars) | **on**   | `REGEXP (?i)pat` | none        |
+//! | regex-metachar pattern | off      | `REGEXP pat`     | none        |
+//! | regex-metachar pattern | **on**   | `REGEXP (?i)pat` | none        |
+//!
+//! # Case-sensitivity matrix
+//!
+//! SQLite's built-in `LIKE` is ASCII case-insensitive (`A-Z` ↔ `a-z` only).
+//! Without `-i` the Rust `str::contains` post-filter re-narrows to an exact
+//! byte match, so user-facing behavior is strictly case-sensitive. With `-i`
+//! we hand the pattern to the Rust `regex` crate via REGEXP, prefixed with
+//! `(?i)`, which applies Unicode *simple* case folding (1:1 mappings only,
+//! e.g. `Å`↔`å`, `Σ`↔`σ`). The `ß`↔`SS` 1:2 mapping is *full* case folding,
+//! which Rust's regex does not implement.
+//!
+//! |                     | ASCII case | non-ASCII 1:1 | `ß`↔`SS` (1:2) |
+//! | ------------------- | ---------- | ------------- | --------------- |
+//! | LIKE + verify       | strict     | strict        | no              |
+//! | REGEXP, no `-i`     | strict     | strict        | no              |
+//! | REGEXP with `(?i)`  | folded     | folded        | **no**          |
+//!
+//! Each row below has at least one test that pins its cell.
+//!
+//! Notes:
+//! - "Folded" here is Unicode simple case folding. NFKC folding (stripping
+//!   diacritics) is not applied — so `björk` and `bjork` are distinct under
+//!   `-i`. The sharp-S `ß` is not folded to `SS` either — that's a full-fold
+//!   mapping that the `regex` crate does not implement. `ẞ`↔`ß` is 1:1 and
+//!   *is* folded.
 
 use etp_lib::db;
 use etp_lib::ops;
@@ -8,12 +43,17 @@ use etp_lib::scanner;
 use std::fs;
 
 fn make_fixture(dir: &std::path::Path) {
-    // Mix of filenames exercising case, Unicode, and special chars.
+    // ASCII case variants
     fs::write(dir.join("Swans - The Seer.flac"), b"x").unwrap();
     fs::write(dir.join("swans-demo.mp3"), b"x").unwrap();
     fs::write(dir.join("SWANS_live.mp3"), b"x").unwrap();
+    // Non-ASCII letter (diacritic) — case fold only, no diacritic strip
     fs::write(dir.join("Björk.flac"), b"x").unwrap();
     fs::write(dir.join("bjork.flac"), b"x").unwrap();
+    // German sharp-S fold: ß ↔ SS
+    fs::write(dir.join("Weiße Nächte.flac"), b"x").unwrap();
+    fs::write(dir.join("WEISSE NACHTE.flac"), b"x").unwrap();
+    // LIKE wildcard escaping
     fs::write(dir.join("50% off.txt"), b"x").unwrap();
     fs::write(dir.join("notes_2026.md"), b"x").unwrap();
     fs::create_dir_all(dir.join("sub")).unwrap();
@@ -34,68 +74,106 @@ async fn scanned_pool() -> (sqlx::SqlitePool, i64, tempfile::TempDir) {
     (pool, scan_id, tmp)
 }
 
-#[tokio::test]
-async fn literal_without_i_is_case_sensitive() {
-    // Path: LIKE narrows (ASCII ci); Rust re-verifies case-sensitive.
-    // Only "swans-demo.mp3" and "track01-swans.flac" match "swans".
-    let (pool, scan_id, _tmp) = scanned_pool().await;
+async fn find(pool: &sqlx::SqlitePool, scan_id: i64, pat: &str, i: bool) -> Vec<String> {
     let filter = ops::FilterConfig::new(true);
-
-    let matches = ops::collect_find_matches(&pool, Some(scan_id), "swans", false, &[], &filter)
+    ops::collect_find_matches(pool, Some(scan_id), pat, i, &[], &filter)
         .await
-        .unwrap();
-    let names: Vec<&str> = matches
-        .iter()
-        .map(|m| m.full_path.rsplit('/').next().unwrap())
-        .collect();
-    assert!(names.iter().any(|n| *n == "swans-demo.mp3"), "{names:?}");
+        .unwrap()
+        .into_iter()
+        .map(|m| m.full_path.rsplit('/').next().unwrap().to_string())
+        .collect()
+}
+
+// Dispatch tests (which SQL op each (pattern, -i) combination takes) live in
+// `ops::tests::build_find_op_*` as unit tests since they need access to the
+// private `build_find_op` helper. This file focuses on end-to-end behavior.
+
+// ─── LIKE + verify path: strict ASCII and Unicode case sensitivity ─────────
+
+#[tokio::test]
+async fn like_ascii_case_strict() {
+    let (pool, scan_id, _tmp) = scanned_pool().await;
+    let names = find(&pool, scan_id, "swans", false).await;
+    // Exact-case matches only — lowercase filenames + lowercase in path.
+    assert!(names.iter().any(|n| n == "swans-demo.mp3"), "{names:?}");
+    assert!(names.iter().any(|n| n == "track01-swans.flac"), "{names:?}");
     assert!(
-        names.iter().any(|n| *n == "track01-swans.flac"),
-        "{names:?}"
+        !names.iter().any(|n| n == "Swans - The Seer.flac"),
+        "mixed-case must NOT match: {names:?}"
     );
     assert!(
-        !names.iter().any(|n| *n == "Swans - The Seer.flac"),
-        "uppercase should not match without -i: {names:?}"
-    );
-    assert!(
-        !names.iter().any(|n| *n == "SWANS_live.mp3"),
-        "allcaps should not match without -i: {names:?}"
+        !names.iter().any(|n| n == "SWANS_live.mp3"),
+        "uppercase must NOT match: {names:?}"
     );
 }
 
 #[tokio::test]
-async fn literal_with_i_matches_unicode_case_fold() {
-    // `-i` takes the REGEXP path with `(?i)` prefix so the Rust regex engine
-    // applies full Unicode case folding (covers björk/Björk).
+async fn like_non_ascii_case_strict() {
     let (pool, scan_id, _tmp) = scanned_pool().await;
-    let filter = ops::FilterConfig::new(true);
-
-    let matches = ops::collect_find_matches(&pool, Some(scan_id), "björk", true, &[], &filter)
-        .await
-        .unwrap();
-    let names: Vec<String> = matches
-        .iter()
-        .map(|m| m.full_path.rsplit('/').next().unwrap().to_string())
-        .collect();
-    assert!(names.iter().any(|n| n == "Björk.flac"), "{names:?}");
-    // Note: "bjork" (no diacritic) is not a case fold of "björk" so the
-    // diacritic-stripped filename does not match this pattern. Fold-to-NFD
-    // ASCII folding would be needed for that, which Rust's regex doesn't do.
+    // "björk" (lowercase, with umlaut) only matches exact casing.
+    let names = find(&pool, scan_id, "björk", false).await;
+    assert!(
+        !names.iter().any(|n| n == "Björk.flac"),
+        "non-ASCII uppercase must NOT match without -i: {names:?}"
+    );
+    assert!(
+        !names.iter().any(|n| n == "bjork.flac"),
+        "diacritic-stripped variant must NOT match: {names:?}"
+    );
+    // No files in the fixture have exact lowercase-with-umlaut "björk".
+    assert!(names.is_empty(), "no exact-case match expected: {names:?}");
 }
 
 #[tokio::test]
-async fn literal_with_i_matches_all_case_variants() {
+async fn like_sharp_s_not_folded() {
     let (pool, scan_id, _tmp) = scanned_pool().await;
-    let filter = ops::FilterConfig::new(true);
+    // "weiße" should NOT match "WEISSE" without -i.
+    let names = find(&pool, scan_id, "weiße", false).await;
+    assert!(
+        !names.iter().any(|n| n == "WEISSE NACHTE.flac"),
+        "ß must not fold to SS without -i: {names:?}"
+    );
+    assert!(names.is_empty(), "{names:?}");
+}
 
-    let matches = ops::collect_find_matches(&pool, Some(scan_id), "swans", true, &[], &filter)
-        .await
-        .unwrap();
-    let names: Vec<String> = matches
-        .iter()
-        .map(|m| m.full_path.rsplit('/').next().unwrap().to_string())
-        .collect();
-    // With -i: lowercase, mixed, and uppercase all match.
+// ─── REGEXP no -i: strict ASCII and Unicode case sensitivity ────────────────
+
+#[tokio::test]
+async fn regexp_no_i_ascii_case_strict() {
+    let (pool, scan_id, _tmp) = scanned_pool().await;
+    // `sw.*s` only hits lowercase s...s runs.
+    let names = find(&pool, scan_id, "sw.*s", false).await;
+    assert!(names.iter().any(|n| n == "swans-demo.mp3"));
+    assert!(names.iter().any(|n| n == "track01-swans.flac"));
+    assert!(
+        !names.iter().any(|n| n == "Swans - The Seer.flac"),
+        "Upper-S must not match regex without -i: {names:?}"
+    );
+    assert!(
+        !names.iter().any(|n| n == "SWANS_live.mp3"),
+        "all-caps must not match: {names:?}"
+    );
+}
+
+#[tokio::test]
+async fn regexp_no_i_non_ascii_case_strict() {
+    let (pool, scan_id, _tmp) = scanned_pool().await;
+    // `bj.rk` only matches exact case — "Björk" starts with "B".
+    let names = find(&pool, scan_id, "bj.rk", false).await;
+    assert!(names.iter().any(|n| n == "bjork.flac"), "{names:?}");
+    assert!(
+        !names.iter().any(|n| n == "Björk.flac"),
+        "Upper-B must not match regex without -i: {names:?}"
+    );
+}
+
+// ─── REGEXP with -i: Unicode case-folded matching ───────────────────────────
+
+#[tokio::test]
+async fn regexp_with_i_ascii_case_folded() {
+    let (pool, scan_id, _tmp) = scanned_pool().await;
+    let names = find(&pool, scan_id, "swans", true).await;
+    // Every casing variant matches under -i.
     assert!(names.iter().any(|n| n == "swans-demo.mp3"));
     assert!(names.iter().any(|n| n == "Swans - The Seer.flac"));
     assert!(names.iter().any(|n| n == "SWANS_live.mp3"));
@@ -103,57 +181,65 @@ async fn literal_with_i_matches_all_case_variants() {
 }
 
 #[tokio::test]
-async fn regex_pattern_uses_regexp_udf() {
-    // A real regex (with metachars) must go through the REGEXP UDF. The UDF
-    // is case-sensitive without -i, case-insensitive with -i.
+async fn regexp_with_i_non_ascii_case_folded() {
     let (pool, scan_id, _tmp) = scanned_pool().await;
-    let filter = ops::FilterConfig::new(true);
-
-    // "sw.*s" matches "swans" in lowercase filenames only (no -i).
-    let matches = ops::collect_find_matches(&pool, Some(scan_id), "sw.*s", false, &[], &filter)
-        .await
-        .unwrap();
-    let names: Vec<String> = matches
-        .iter()
-        .map(|m| m.full_path.rsplit('/').next().unwrap().to_string())
-        .collect();
-    assert!(names.iter().any(|n| n == "swans-demo.mp3"));
-    assert!(names.iter().any(|n| n == "track01-swans.flac"));
+    // "björk" folds to match "Björk" (same letters, just case).
+    let names = find(&pool, scan_id, "björk", true).await;
+    assert!(names.iter().any(|n| n == "Björk.flac"), "{names:?}");
+    // But "bjork" (no diacritic) is a distinct grapheme and must NOT match.
     assert!(
-        !names.iter().any(|n| n == "Swans - The Seer.flac"),
-        "Upper-S should not match regex sw.*s without -i: {names:?}"
+        !names.iter().any(|n| n == "bjork.flac"),
+        "Unicode case fold does not strip diacritics: {names:?}"
     );
 }
 
 #[tokio::test]
-async fn like_pattern_escapes_wildcards() {
-    // "50%" is a literal (no regex metachars); LIKE path must escape the %.
+async fn regexp_with_i_sharp_s_is_not_ss_folded() {
     let (pool, scan_id, _tmp) = scanned_pool().await;
-    let filter = ops::FilterConfig::new(true);
+    // Pattern "weisse" with -i matches the ASCII "WEISSE" variant (s ↔ S is
+    // 1:1). It does NOT match "Weiße" because `ß` ↔ `SS` is a 1:2 full-fold
+    // mapping that Rust's regex crate does not implement.
+    let names = find(&pool, scan_id, "weisse", true).await;
+    assert!(
+        names.iter().any(|n| n == "WEISSE NACHTE.flac"),
+        "ASCII case fold must apply: {names:?}"
+    );
+    assert!(
+        !names.iter().any(|n| n == "Weiße Nächte.flac"),
+        "ß ↔ SS is a 1:2 full-fold mapping that is NOT applied: {names:?}"
+    );
+}
 
-    let matches = ops::collect_find_matches(&pool, Some(scan_id), "50%", false, &[], &filter)
-        .await
-        .unwrap();
-    let names: Vec<String> = matches
-        .iter()
-        .map(|m| m.full_path.rsplit('/').next().unwrap().to_string())
-        .collect();
+#[tokio::test]
+async fn regexp_with_i_sharp_s_pattern_matches_exact() {
+    let (pool, scan_id, _tmp) = scanned_pool().await;
+    // Pattern containing `ß` matches the filename that contains `ß` (same
+    // letters, different case on the surrounding ASCII).
+    let names = find(&pool, scan_id, "weiße", true).await;
+    assert!(
+        names.iter().any(|n| n == "Weiße Nächte.flac"),
+        "exact ß match with ASCII case fold: {names:?}"
+    );
+    assert!(
+        !names.iter().any(|n| n == "WEISSE NACHTE.flac"),
+        "ß in pattern should not fold to match SS in filename: {names:?}"
+    );
+}
+
+// ─── LIKE wildcard escaping ────────────────────────────────────────────────
+
+#[tokio::test]
+async fn like_escapes_percent_wildcard() {
+    let (pool, scan_id, _tmp) = scanned_pool().await;
+    // Literal `%` must be escaped so LIKE treats it as a literal char.
+    let names = find(&pool, scan_id, "50%", false).await;
     assert_eq!(names, vec!["50% off.txt".to_string()], "{names:?}");
 }
 
 #[tokio::test]
-async fn underscore_in_literal_is_escaped() {
-    // "_2026" is literal. LIKE path must escape the _ so it doesn't match
-    // any single char (which would match "SWANS_live.mp3" via " live" etc.).
+async fn like_escapes_underscore_wildcard() {
     let (pool, scan_id, _tmp) = scanned_pool().await;
-    let filter = ops::FilterConfig::new(true);
-
-    let matches = ops::collect_find_matches(&pool, Some(scan_id), "_2026", false, &[], &filter)
-        .await
-        .unwrap();
-    let names: Vec<String> = matches
-        .iter()
-        .map(|m| m.full_path.rsplit('/').next().unwrap().to_string())
-        .collect();
+    // `_` is a LIKE single-char wildcard; must be escaped to match literally.
+    let names = find(&pool, scan_id, "_2026", false).await;
     assert_eq!(names, vec!["notes_2026.md".to_string()], "{names:?}");
 }

--- a/crates/etp-lib/tests/find_sql_pushdown.rs
+++ b/crates/etp-lib/tests/find_sql_pushdown.rs
@@ -1,0 +1,159 @@
+//! Behavior tests for `-i` → REGEXP UDF, literal → LIKE, and regex → REGEXP
+//! in `collect_find_matches` / `stream_find_matches`. Exercises the real
+//! sqlx-sqlite REGEXP UDF registered by `with_regexp()`.
+
+use etp_lib::db;
+use etp_lib::ops;
+use etp_lib::scanner;
+use std::fs;
+
+fn make_fixture(dir: &std::path::Path) {
+    // Mix of filenames exercising case, Unicode, and special chars.
+    fs::write(dir.join("Swans - The Seer.flac"), b"x").unwrap();
+    fs::write(dir.join("swans-demo.mp3"), b"x").unwrap();
+    fs::write(dir.join("SWANS_live.mp3"), b"x").unwrap();
+    fs::write(dir.join("Björk.flac"), b"x").unwrap();
+    fs::write(dir.join("bjork.flac"), b"x").unwrap();
+    fs::write(dir.join("50% off.txt"), b"x").unwrap();
+    fs::write(dir.join("notes_2026.md"), b"x").unwrap();
+    fs::create_dir_all(dir.join("sub")).unwrap();
+    fs::write(dir.join("sub/track01-swans.flac"), b"x").unwrap();
+}
+
+async fn scanned_pool() -> (sqlx::SqlitePool, i64, tempfile::TempDir) {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("fixture");
+    fs::create_dir(&root).unwrap();
+    make_fixture(&root);
+
+    let pool = db::open_memory().await.unwrap();
+    let run_type = root.to_string_lossy();
+    let (scan_id, _stats) = scanner::scan_to_db(&root, &pool, &run_type, &[], false, None)
+        .await
+        .unwrap();
+    (pool, scan_id, tmp)
+}
+
+#[tokio::test]
+async fn literal_without_i_is_case_sensitive() {
+    // Path: LIKE narrows (ASCII ci); Rust re-verifies case-sensitive.
+    // Only "swans-demo.mp3" and "track01-swans.flac" match "swans".
+    let (pool, scan_id, _tmp) = scanned_pool().await;
+    let filter = ops::FilterConfig::new(true);
+
+    let matches = ops::collect_find_matches(&pool, Some(scan_id), "swans", false, &[], &filter)
+        .await
+        .unwrap();
+    let names: Vec<&str> = matches
+        .iter()
+        .map(|m| m.full_path.rsplit('/').next().unwrap())
+        .collect();
+    assert!(names.iter().any(|n| *n == "swans-demo.mp3"), "{names:?}");
+    assert!(
+        names.iter().any(|n| *n == "track01-swans.flac"),
+        "{names:?}"
+    );
+    assert!(
+        !names.iter().any(|n| *n == "Swans - The Seer.flac"),
+        "uppercase should not match without -i: {names:?}"
+    );
+    assert!(
+        !names.iter().any(|n| *n == "SWANS_live.mp3"),
+        "allcaps should not match without -i: {names:?}"
+    );
+}
+
+#[tokio::test]
+async fn literal_with_i_matches_unicode_case_fold() {
+    // `-i` takes the REGEXP path with `(?i)` prefix so the Rust regex engine
+    // applies full Unicode case folding (covers björk/Björk).
+    let (pool, scan_id, _tmp) = scanned_pool().await;
+    let filter = ops::FilterConfig::new(true);
+
+    let matches = ops::collect_find_matches(&pool, Some(scan_id), "björk", true, &[], &filter)
+        .await
+        .unwrap();
+    let names: Vec<String> = matches
+        .iter()
+        .map(|m| m.full_path.rsplit('/').next().unwrap().to_string())
+        .collect();
+    assert!(names.iter().any(|n| n == "Björk.flac"), "{names:?}");
+    // Note: "bjork" (no diacritic) is not a case fold of "björk" so the
+    // diacritic-stripped filename does not match this pattern. Fold-to-NFD
+    // ASCII folding would be needed for that, which Rust's regex doesn't do.
+}
+
+#[tokio::test]
+async fn literal_with_i_matches_all_case_variants() {
+    let (pool, scan_id, _tmp) = scanned_pool().await;
+    let filter = ops::FilterConfig::new(true);
+
+    let matches = ops::collect_find_matches(&pool, Some(scan_id), "swans", true, &[], &filter)
+        .await
+        .unwrap();
+    let names: Vec<String> = matches
+        .iter()
+        .map(|m| m.full_path.rsplit('/').next().unwrap().to_string())
+        .collect();
+    // With -i: lowercase, mixed, and uppercase all match.
+    assert!(names.iter().any(|n| n == "swans-demo.mp3"));
+    assert!(names.iter().any(|n| n == "Swans - The Seer.flac"));
+    assert!(names.iter().any(|n| n == "SWANS_live.mp3"));
+    assert!(names.iter().any(|n| n == "track01-swans.flac"));
+}
+
+#[tokio::test]
+async fn regex_pattern_uses_regexp_udf() {
+    // A real regex (with metachars) must go through the REGEXP UDF. The UDF
+    // is case-sensitive without -i, case-insensitive with -i.
+    let (pool, scan_id, _tmp) = scanned_pool().await;
+    let filter = ops::FilterConfig::new(true);
+
+    // "sw.*s" matches "swans" in lowercase filenames only (no -i).
+    let matches = ops::collect_find_matches(&pool, Some(scan_id), "sw.*s", false, &[], &filter)
+        .await
+        .unwrap();
+    let names: Vec<String> = matches
+        .iter()
+        .map(|m| m.full_path.rsplit('/').next().unwrap().to_string())
+        .collect();
+    assert!(names.iter().any(|n| n == "swans-demo.mp3"));
+    assert!(names.iter().any(|n| n == "track01-swans.flac"));
+    assert!(
+        !names.iter().any(|n| n == "Swans - The Seer.flac"),
+        "Upper-S should not match regex sw.*s without -i: {names:?}"
+    );
+}
+
+#[tokio::test]
+async fn like_pattern_escapes_wildcards() {
+    // "50%" is a literal (no regex metachars); LIKE path must escape the %.
+    let (pool, scan_id, _tmp) = scanned_pool().await;
+    let filter = ops::FilterConfig::new(true);
+
+    let matches = ops::collect_find_matches(&pool, Some(scan_id), "50%", false, &[], &filter)
+        .await
+        .unwrap();
+    let names: Vec<String> = matches
+        .iter()
+        .map(|m| m.full_path.rsplit('/').next().unwrap().to_string())
+        .collect();
+    assert_eq!(names, vec!["50% off.txt".to_string()], "{names:?}");
+}
+
+#[tokio::test]
+async fn underscore_in_literal_is_escaped() {
+    // "_2026" is literal. LIKE path must escape the _ so it doesn't match
+    // any single char (which would match "SWANS_live.mp3" via " live" etc.).
+    let (pool, scan_id, _tmp) = scanned_pool().await;
+    let filter = ops::FilterConfig::new(true);
+
+    let matches = ops::collect_find_matches(&pool, Some(scan_id), "_2026", false, &[], &filter)
+        .await
+        .unwrap();
+    let names: Vec<String> = matches
+        .iter()
+        .map(|m| m.full_path.rsplit('/').next().unwrap().to_string())
+        .collect();
+    assert_eq!(names, vec!["notes_2026.md".to_string()], "{names:?}");
+}

--- a/crates/etp-lib/tests/find_sql_pushdown.rs
+++ b/crates/etp-lib/tests/find_sql_pushdown.rs
@@ -54,6 +54,11 @@ fn make_fixture(dir: &std::path::Path) {
     fs::write(dir.join("notes_2026.md"), b"x").unwrap();
     fs::create_dir_all(dir.join("sub")).unwrap();
     fs::write(dir.join("sub/track01-swans.flac"), b"x").unwrap();
+    // System-file shapes used by the SQL-layer filter tests.
+    fs::create_dir_all(dir.join("@eaDir/SYNOLOGY")).unwrap();
+    fs::write(dir.join("@eaDir/SYNOLOGY/Swans@eadir-thumb.jpg"), b"x").unwrap();
+    fs::write(dir.join("@eaDir/SYNOLOGY/swans-eaDir-inside.flac"), b"x").unwrap();
+    fs::write(dir.join("sub/.etp.db"), b"x").unwrap();
 }
 
 async fn scanned_pool() -> (sqlx::SqlitePool, i64, tempfile::TempDir) {
@@ -71,7 +76,25 @@ async fn scanned_pool() -> (sqlx::SqlitePool, i64, tempfile::TempDir) {
 }
 
 async fn find(pool: &sqlx::SqlitePool, scan_id: i64, pat: &str, i: bool) -> Vec<String> {
+    // include_system_files=true — keeps system paths visible for the case-
+    // sensitivity tests that don't care about the system filter.
     let filter = ops::FilterConfig::new(true);
+    ops::collect_find_matches(pool, Some(scan_id), pat, i, &[], &filter)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|m| m.full_path.rsplit('/').next().unwrap().to_string())
+        .collect()
+}
+
+async fn find_with_filter(
+    pool: &sqlx::SqlitePool,
+    scan_id: i64,
+    pat: &str,
+    i: bool,
+    include_system: bool,
+) -> Vec<String> {
+    let filter = ops::FilterConfig::new(include_system);
     ops::collect_find_matches(pool, Some(scan_id), pat, i, &[], &filter)
         .await
         .unwrap()
@@ -205,4 +228,60 @@ async fn underscore_is_literal_in_regex() {
     let (pool, scan_id, _tmp) = scanned_pool().await;
     let names = find(&pool, scan_id, "_2026", false).await;
     assert_eq!(names, vec!["notes_2026.md".to_string()], "{names:?}");
+}
+
+// ─── SQL-layer system-file exclusion ────────────────────────────────────────
+
+#[tokio::test]
+async fn system_filter_default_hides_eadir_children() {
+    // Default filter (include_system=false) must drop anything inside @eaDir,
+    // even when the pattern matches its contents.
+    let (pool, scan_id, _tmp) = scanned_pool().await;
+    let names = find_with_filter(&pool, scan_id, "(?i)swans", true, false).await;
+    // Should surface the real Swans files...
+    assert!(names.iter().any(|n| n == "swans-demo.mp3"));
+    assert!(names.iter().any(|n| n == "Swans - The Seer.flac"));
+    assert!(names.iter().any(|n| n == "track01-swans.flac"));
+    // ...but not @eaDir descendants, even though they contain "swans".
+    assert!(
+        !names.iter().any(|n| n == "Swans@eadir-thumb.jpg"),
+        "file inside @eaDir must be hidden: {names:?}"
+    );
+    assert!(
+        !names.iter().any(|n| n == "swans-eaDir-inside.flac"),
+        "file inside @eaDir must be hidden: {names:?}"
+    );
+}
+
+#[tokio::test]
+async fn system_filter_include_shows_eadir_children() {
+    // With include_system_files=true the SQL filter is bypassed entirely and
+    // @eaDir contents appear in the results.
+    let (pool, scan_id, _tmp) = scanned_pool().await;
+    let names = find_with_filter(&pool, scan_id, "(?i)swans", true, true).await;
+    assert!(
+        names.iter().any(|n| n == "Swans@eadir-thumb.jpg"),
+        "{names:?}"
+    );
+    assert!(
+        names.iter().any(|n| n == "swans-eaDir-inside.flac"),
+        "{names:?}"
+    );
+}
+
+#[tokio::test]
+async fn system_filter_hides_etp_db_filename() {
+    // `.etp.db` is a system-pattern filename. It must be excluded by default.
+    let (pool, scan_id, _tmp) = scanned_pool().await;
+    let default_names = find_with_filter(&pool, scan_id, "etp", false, false).await;
+    assert!(
+        !default_names.iter().any(|n| n == ".etp.db"),
+        "default filter must hide .etp.db: {default_names:?}"
+    );
+
+    let include_names = find_with_filter(&pool, scan_id, "etp", false, true).await;
+    assert!(
+        include_names.iter().any(|n| n == ".etp.db"),
+        "include_system must surface .etp.db: {include_names:?}"
+    );
 }

--- a/crates/etp-lib/tests/find_sql_pushdown.rs
+++ b/crates/etp-lib/tests/find_sql_pushdown.rs
@@ -1,41 +1,37 @@
 //! Behavior tests for `etp-find`'s SQL-pushdown pattern matching.
 //!
-//! # Dispatch matrix
+//! # Dispatch
 //!
-//! Three strategies are dispatched by [`ops::collect_find_matches`] /
-//! [`ops::stream_find_matches`] based on `(pattern shape, -i)`:
+//! Every search runs through SQLite's REGEXP UDF (registered by
+//! `with_regexp()`), backed by the Rust `regex` crate. `-i` is expressed as a
+//! `(?i)` prefix on the pattern so case folding happens inside the regex
+//! engine. There is no separate LIKE path.
 //!
-//! | pattern shape          | `-i`     | SQL op           | post-filter |
-//! | ---------------------- | -------- | ---------------- | ----------- |
-//! | literal (no metachars) | off      | `LIKE … ESCAPE`  | `contains`  |
-//! | literal (no metachars) | **on**   | `REGEXP (?i)pat` | none        |
-//! | regex-metachar pattern | off      | `REGEXP pat`     | none        |
-//! | regex-metachar pattern | **on**   | `REGEXP (?i)pat` | none        |
+//! | `-i`     | SQL op                   | example pattern sent to SQLite |
+//! | -------- | ------------------------ | ------------------------------ |
+//! | off      | `… REGEXP ?`             | `swans`                        |
+//! | **on**   | `… REGEXP ?` with `(?i)` | `(?i)swans`                    |
 //!
 //! # Case-sensitivity matrix
 //!
-//! SQLite's built-in `LIKE` is ASCII case-insensitive (`A-Z` ↔ `a-z` only).
-//! Without `-i` the Rust `str::contains` post-filter re-narrows to an exact
-//! byte match, so user-facing behavior is strictly case-sensitive. With `-i`
-//! we hand the pattern to the Rust `regex` crate via REGEXP, prefixed with
-//! `(?i)`, which applies Unicode *simple* case folding (1:1 mappings only,
-//! e.g. `Å`↔`å`, `Σ`↔`σ`). The `ß`↔`SS` 1:2 mapping is *full* case folding,
-//! which Rust's regex does not implement.
+//! With `-i` off, the pattern is case-sensitive. With `-i` on, the Rust
+//! `regex` crate applies Unicode *simple* case folding (1:1 mappings only,
+//! e.g. `Å`↔`å`, `Σ`↔`σ`, `ẞ`↔`ß`). The `ß`↔`SS` 1:2 mapping is *full* case
+//! folding, which Rust's regex does not implement.
 //!
-//! |                     | ASCII case | non-ASCII 1:1 | `ß`↔`SS` (1:2) |
-//! | ------------------- | ---------- | ------------- | --------------- |
-//! | LIKE + verify       | strict     | strict        | no              |
-//! | REGEXP, no `-i`     | strict     | strict        | no              |
-//! | REGEXP with `(?i)`  | folded     | folded        | **no**          |
+//! |                      | ASCII case | non-ASCII 1:1 | `ß`↔`SS` (1:2) |
+//! | -------------------- | ---------- | ------------- | --------------- |
+//! | REGEXP, no `-i`      | strict     | strict        | no              |
+//! | REGEXP with `(?i)`   | folded     | folded        | **no**          |
 //!
 //! Each row below has at least one test that pins its cell.
 //!
 //! Notes:
-//! - "Folded" here is Unicode simple case folding. NFKC folding (stripping
-//!   diacritics) is not applied — so `björk` and `bjork` are distinct under
-//!   `-i`. The sharp-S `ß` is not folded to `SS` either — that's a full-fold
-//!   mapping that the `regex` crate does not implement. `ẞ`↔`ß` is 1:1 and
-//!   *is* folded.
+//! - NFKC folding (stripping diacritics) is not applied — `björk` and `bjork`
+//!   are distinct under `-i`.
+//! - LIKE wildcards (`%`, `_`) have no special meaning here since we never
+//!   call LIKE. A pattern like `50%` is a valid regex that matches literal
+//!   `50%` (`%` is not a regex metacharacter).
 
 use etp_lib::db;
 use etp_lib::ops;
@@ -50,10 +46,10 @@ fn make_fixture(dir: &std::path::Path) {
     // Non-ASCII letter (diacritic) — case fold only, no diacritic strip
     fs::write(dir.join("Björk.flac"), b"x").unwrap();
     fs::write(dir.join("bjork.flac"), b"x").unwrap();
-    // German sharp-S fold: ß ↔ SS
+    // German sharp-S fold: ß ↔ SS (1:2, not applied)
     fs::write(dir.join("Weiße Nächte.flac"), b"x").unwrap();
     fs::write(dir.join("WEISSE NACHTE.flac"), b"x").unwrap();
-    // LIKE wildcard escaping
+    // Special chars that happen not to be regex metacharacters
     fs::write(dir.join("50% off.txt"), b"x").unwrap();
     fs::write(dir.join("notes_2026.md"), b"x").unwrap();
     fs::create_dir_all(dir.join("sub")).unwrap();
@@ -84,17 +80,12 @@ async fn find(pool: &sqlx::SqlitePool, scan_id: i64, pat: &str, i: bool) -> Vec<
         .collect()
 }
 
-// Dispatch tests (which SQL op each (pattern, -i) combination takes) live in
-// `ops::tests::build_find_op_*` as unit tests since they need access to the
-// private `build_find_op` helper. This file focuses on end-to-end behavior.
-
-// ─── LIKE + verify path: strict ASCII and Unicode case sensitivity ─────────
+// ─── REGEXP no -i: strict ASCII, non-ASCII, and ß ──────────────────────────
 
 #[tokio::test]
-async fn like_ascii_case_strict() {
+async fn without_i_ascii_case_strict() {
     let (pool, scan_id, _tmp) = scanned_pool().await;
     let names = find(&pool, scan_id, "swans", false).await;
-    // Exact-case matches only — lowercase filenames + lowercase in path.
     assert!(names.iter().any(|n| n == "swans-demo.mp3"), "{names:?}");
     assert!(names.iter().any(|n| n == "track01-swans.flac"), "{names:?}");
     assert!(
@@ -108,26 +99,35 @@ async fn like_ascii_case_strict() {
 }
 
 #[tokio::test]
-async fn like_non_ascii_case_strict() {
+async fn without_i_regex_metachars_still_case_strict() {
     let (pool, scan_id, _tmp) = scanned_pool().await;
-    // "björk" (lowercase, with umlaut) only matches exact casing.
+    let names = find(&pool, scan_id, "sw.*s", false).await;
+    assert!(names.iter().any(|n| n == "swans-demo.mp3"));
+    assert!(names.iter().any(|n| n == "track01-swans.flac"));
+    assert!(
+        !names.iter().any(|n| n == "Swans - The Seer.flac"),
+        "Upper-S must not match without -i: {names:?}"
+    );
+}
+
+#[tokio::test]
+async fn without_i_non_ascii_case_strict() {
+    let (pool, scan_id, _tmp) = scanned_pool().await;
     let names = find(&pool, scan_id, "björk", false).await;
     assert!(
         !names.iter().any(|n| n == "Björk.flac"),
-        "non-ASCII uppercase must NOT match without -i: {names:?}"
+        "non-ASCII uppercase must NOT match: {names:?}"
     );
     assert!(
         !names.iter().any(|n| n == "bjork.flac"),
         "diacritic-stripped variant must NOT match: {names:?}"
     );
-    // No files in the fixture have exact lowercase-with-umlaut "björk".
     assert!(names.is_empty(), "no exact-case match expected: {names:?}");
 }
 
 #[tokio::test]
-async fn like_sharp_s_not_folded() {
+async fn without_i_sharp_s_not_folded() {
     let (pool, scan_id, _tmp) = scanned_pool().await;
-    // "weiße" should NOT match "WEISSE" without -i.
     let names = find(&pool, scan_id, "weiße", false).await;
     assert!(
         !names.iter().any(|n| n == "WEISSE NACHTE.flac"),
@@ -136,44 +136,12 @@ async fn like_sharp_s_not_folded() {
     assert!(names.is_empty(), "{names:?}");
 }
 
-// ─── REGEXP no -i: strict ASCII and Unicode case sensitivity ────────────────
+// ─── REGEXP with -i: Unicode simple case folding ───────────────────────────
 
 #[tokio::test]
-async fn regexp_no_i_ascii_case_strict() {
-    let (pool, scan_id, _tmp) = scanned_pool().await;
-    // `sw.*s` only hits lowercase s...s runs.
-    let names = find(&pool, scan_id, "sw.*s", false).await;
-    assert!(names.iter().any(|n| n == "swans-demo.mp3"));
-    assert!(names.iter().any(|n| n == "track01-swans.flac"));
-    assert!(
-        !names.iter().any(|n| n == "Swans - The Seer.flac"),
-        "Upper-S must not match regex without -i: {names:?}"
-    );
-    assert!(
-        !names.iter().any(|n| n == "SWANS_live.mp3"),
-        "all-caps must not match: {names:?}"
-    );
-}
-
-#[tokio::test]
-async fn regexp_no_i_non_ascii_case_strict() {
-    let (pool, scan_id, _tmp) = scanned_pool().await;
-    // `bj.rk` only matches exact case — "Björk" starts with "B".
-    let names = find(&pool, scan_id, "bj.rk", false).await;
-    assert!(names.iter().any(|n| n == "bjork.flac"), "{names:?}");
-    assert!(
-        !names.iter().any(|n| n == "Björk.flac"),
-        "Upper-B must not match regex without -i: {names:?}"
-    );
-}
-
-// ─── REGEXP with -i: Unicode case-folded matching ───────────────────────────
-
-#[tokio::test]
-async fn regexp_with_i_ascii_case_folded() {
+async fn with_i_ascii_case_folded() {
     let (pool, scan_id, _tmp) = scanned_pool().await;
     let names = find(&pool, scan_id, "swans", true).await;
-    // Every casing variant matches under -i.
     assert!(names.iter().any(|n| n == "swans-demo.mp3"));
     assert!(names.iter().any(|n| n == "Swans - The Seer.flac"));
     assert!(names.iter().any(|n| n == "SWANS_live.mp3"));
@@ -181,12 +149,10 @@ async fn regexp_with_i_ascii_case_folded() {
 }
 
 #[tokio::test]
-async fn regexp_with_i_non_ascii_case_folded() {
+async fn with_i_non_ascii_case_folded() {
     let (pool, scan_id, _tmp) = scanned_pool().await;
-    // "björk" folds to match "Björk" (same letters, just case).
     let names = find(&pool, scan_id, "björk", true).await;
     assert!(names.iter().any(|n| n == "Björk.flac"), "{names:?}");
-    // But "bjork" (no diacritic) is a distinct grapheme and must NOT match.
     assert!(
         !names.iter().any(|n| n == "bjork.flac"),
         "Unicode case fold does not strip diacritics: {names:?}"
@@ -194,11 +160,10 @@ async fn regexp_with_i_non_ascii_case_folded() {
 }
 
 #[tokio::test]
-async fn regexp_with_i_sharp_s_is_not_ss_folded() {
+async fn with_i_sharp_s_is_not_ss_folded() {
     let (pool, scan_id, _tmp) = scanned_pool().await;
-    // Pattern "weisse" with -i matches the ASCII "WEISSE" variant (s ↔ S is
-    // 1:1). It does NOT match "Weiße" because `ß` ↔ `SS` is a 1:2 full-fold
-    // mapping that Rust's regex crate does not implement.
+    // `s`↔`S` is 1:1 so `weisse` matches `WEISSE`, but ß↔SS is a 1:2 full-fold
+    // mapping that Rust's regex doesn't implement.
     let names = find(&pool, scan_id, "weisse", true).await;
     assert!(
         names.iter().any(|n| n == "WEISSE NACHTE.flac"),
@@ -206,19 +171,17 @@ async fn regexp_with_i_sharp_s_is_not_ss_folded() {
     );
     assert!(
         !names.iter().any(|n| n == "Weiße Nächte.flac"),
-        "ß ↔ SS is a 1:2 full-fold mapping that is NOT applied: {names:?}"
+        "ß ↔ SS is a 1:2 full-fold that is NOT applied: {names:?}"
     );
 }
 
 #[tokio::test]
-async fn regexp_with_i_sharp_s_pattern_matches_exact() {
+async fn with_i_sharp_s_pattern_matches_exact() {
     let (pool, scan_id, _tmp) = scanned_pool().await;
-    // Pattern containing `ß` matches the filename that contains `ß` (same
-    // letters, different case on the surrounding ASCII).
     let names = find(&pool, scan_id, "weiße", true).await;
     assert!(
         names.iter().any(|n| n == "Weiße Nächte.flac"),
-        "exact ß match with ASCII case fold: {names:?}"
+        "exact ß match with ASCII case fold on the rest: {names:?}"
     );
     assert!(
         !names.iter().any(|n| n == "WEISSE NACHTE.flac"),
@@ -226,20 +189,20 @@ async fn regexp_with_i_sharp_s_pattern_matches_exact() {
     );
 }
 
-// ─── LIKE wildcard escaping ────────────────────────────────────────────────
+// ─── Regex metacharacters are interpreted as regex ──────────────────────────
 
 #[tokio::test]
-async fn like_escapes_percent_wildcard() {
+async fn percent_is_literal_in_regex() {
+    // `%` is not a regex metacharacter, so `50%` matches literal "50%".
     let (pool, scan_id, _tmp) = scanned_pool().await;
-    // Literal `%` must be escaped so LIKE treats it as a literal char.
     let names = find(&pool, scan_id, "50%", false).await;
     assert_eq!(names, vec!["50% off.txt".to_string()], "{names:?}");
 }
 
 #[tokio::test]
-async fn like_escapes_underscore_wildcard() {
+async fn underscore_is_literal_in_regex() {
+    // `_` is not a regex metacharacter either.
     let (pool, scan_id, _tmp) = scanned_pool().await;
-    // `_` is a LIKE single-char wildcard; must be escaped to match literally.
     let names = find(&pool, scan_id, "_2026", false).await;
     assert_eq!(names, vec!["notes_2026.md".to_string()], "{names:?}");
 }

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -55,7 +55,9 @@ Library crate (`crates/etp-lib/src/lib.rs`) re-exports shared modules:
 - `scanner.rs` — walkdir-based scanning; skips unchanged directories by mtime
 - `csv_writer.rs` — sorted CSV output (`path,size,ctime,mtime`)
 - `tree.rs` — tree rendering with ICU4X collation for Unicode-aware sorting
-- `finder.rs` — regex matching against file records
+- `finder.rs` — `FindMatch` struct returned by the DAO-layer match path. The
+  actual regex evaluation runs inside SQLite via the REGEXP UDF (see "Search
+  (etp-find)" below).
 - `metadata.rs` — media metadata reading with dual backend: lofty for audio
   formats, mediainfo subprocess for video (MKV, MP4, AVI) and gap audio (WMA,
   MKA). Extension-based dispatch. Extracts audio properties (duration, bitrate,
@@ -67,7 +69,9 @@ Library crate (`crates/etp-lib/src/lib.rs`) re-exports shared modules:
 - `db/mod.rs` — SQLite connection factory (WAL mode, foreign keys, cache
   pragmas); dual-path init: new databases use clean `schema.sql`, existing
   databases use incremental `migrations/`. FK enforcement disabled during
-  migrations for table recreation compatibility.
+  migrations for table recreation compatibility. `.with_regexp()` registers
+  sqlx's Rust-regex-backed `REGEXP` UDF on every connection so DAO queries can
+  push pattern matching into SQLite (see "Search (etp-find)" below).
 - `db/dao.rs` — all database queries (scan CRUD, file UPSERT, metadata, blobs,
   images, cue sheets, move tracking). `FULL_PATH_SQL` constant for path
   reconstruction used across query functions.
@@ -288,6 +292,59 @@ streaming BLAKE3 hash. Matched files get an UPDATE to `dir_id` + `filename`,
 preserving their ID and all dependent metadata. Unmatched files are deleted with
 dependent cleanup.
 
+### Scanner diagnostics
+
+`scan_to_db` emits `phase: <name> done in <n>s — <stats>` markers on stderr when
+`-v` is passed, covering every post-walk step (stale-directory sweep, move
+reconciliation, CAS blob cleanup, `finish_scan`). The walk loop and the
+reconcile match loop emit a `progress:` / `reconcile:` line every 30 seconds so
+long-running scans report liveness. The markers exist so a scan that appears
+stuck can be triaged in a single re-run rather than guessed at. The
+`csv-verbose` trycmd snapshot pins the format.
+
+## Search (etp-find)
+
+`etp-find` pushes its pattern match into SQLite through the REGEXP UDF
+registered on every connection by `.with_regexp()`. The DAO functions
+`list_files_matching` and `stream_files_matching` issue
+`SELECT … WHERE (<full_path>) REGEXP ?`, where `<full_path>` is the SQL
+concatenation of `root_path`, `directories.path`, and `files.filename`. Only
+matching rows cross the sqlx boundary into Rust.
+
+`-i` is expressed as a `(?i)` prefix on the pattern string before binding, so
+the Rust `regex` crate handles case folding inside the UDF. There is no separate
+case-insensitive SQL operator. Case-sensitivity of `etp-find` is therefore a
+property of the compiled regex:
+
+|              | ASCII case | non-ASCII 1:1 | `ß` ↔ `SS` (1:2) |
+| ------------ | ---------- | ------------- | ---------------- |
+| without `-i` | strict     | strict        | no               |
+| with `-i`    | folded     | folded        | no               |
+
+The `ß` ↔ `SS` 1:2 mapping is _full_ case folding, which the `regex` crate does
+not implement (it does Unicode _simple_ case folding only — see the fixture and
+tests in `crates/etp-lib/tests/find_sql_pushdown.rs`).
+
+When `FilterConfig::include_system_files` is false, the query also gets
+`AND NOT (<full_path>) REGEXP ?` with a second pattern built from
+`filter.system_patterns` via `regex::escape` and component anchors
+(`(?:^|/)…(?:$|/)`). SQLite short-circuits `AND` chains, so rows rejected by the
+user pattern never incur the system-regex evaluation. The compiled regex is
+cached in sqlx-sqlite's per-statement auxdata, so both patterns compile exactly
+once per query.
+
+`ops::stream_find_matches` and `collect_find_matches` take
+`(pattern: &str, insensitive: bool)` and build the final SQL pattern via
+`regexp_pattern()`. After rows arrive, `FilterConfig::should_show_post_sql`
+applies the dotfile and user-exclude checks on the filename alone — it skips the
+expensive `is_system_path` component walk because the SQL layer has already
+applied the system filter (or, when `include_system_files` is true,
+intentionally did not).
+
+See `docs/adrs/2026-04-19-01-regexp-pushdown-for-find.md` for the rationale,
+benchmarks, and the evolution from a dual LIKE+REGEXP dispatch to the single
+REGEXP path.
+
 ## Display Filtering
 
 The scanner indexes everything on disk. Filtering happens at display time via
@@ -313,8 +370,10 @@ System files are exempt from both dotfile hiding and user exclude matching.
 
 `FilterConfig` in `ops.rs` bundles all filter state: system patterns, user
 excludes, `include_system_files`, and `show_hidden`. It provides `should_show()`
-(for full path + filename checks) and `should_show_name()` (for individual name
-checks in tree rendering).
+(for full path + filename checks), `should_show_name()` (for individual name
+checks in tree rendering), and `should_show_post_sql()` (a lean variant used by
+`etp-find` when the SQL layer has already filtered system paths — see "Search
+(etp-find)" above).
 
 ## Runtime Configuration (config.kdl)
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -55,9 +55,9 @@ Library crate (`crates/etp-lib/src/lib.rs`) re-exports shared modules:
 - `scanner.rs` — walkdir-based scanning; skips unchanged directories by mtime
 - `csv_writer.rs` — sorted CSV output (`path,size,ctime,mtime`)
 - `tree.rs` — tree rendering with ICU4X collation for Unicode-aware sorting
-- `finder.rs` — `FindMatch` struct returned by the DAO-layer match path. The
-  actual regex evaluation runs inside SQLite via the REGEXP UDF (see "Search
-  (etp-find)" below).
+- `finder.rs` — `FindMatch` struct (full path + stat fields) returned by the
+  DAO-layer match path. Regex evaluation happens in SQLite via the REGEXP UDF
+  (see "Search (etp-find)" below).
 - `metadata.rs` — media metadata reading with dual backend: lofty for audio
   formats, mediainfo subprocess for video (MKV, MP4, AVI) and gap audio (WMA,
   MKA). Extension-based dispatch. Extracts audio properties (duration, bitrate,

--- a/docs/adrs/2026-04-19-01-regexp-pushdown-for-find.md
+++ b/docs/adrs/2026-04-19-01-regexp-pushdown-for-find.md
@@ -1,0 +1,111 @@
+# Push `etp-find` Pattern Matching into SQLite via REGEXP UDF
+
+- **Status**: Accepted
+- **Date**: 2026-04-19
+
+## Context
+
+`etp-find` originally pulled every row in the `files` table into Rust
+(`stream_all_files` / `list_all_files`), reconstructed each full path with
+`format!`, and tested it against a compiled `regex::Regex`. On the production
+music database (824k files, 278 MB DB) a warm-cache `etp find -i swans` took
+5.52 s wall (8.81 s user CPU). A plain `xsv search` over the same filenames as a
+flat CSV finished in under a second — the gap was not the regex engine, it was:
+
+- Per-row `format!` allocations (two per row: one in `FileRecord` construction,
+  one in `matches_pattern`)
+- `Path::components()` walks in the system-file and dotfile filters
+- sqlx row materialization for rows that would be discarded immediately
+
+Substring grepping a flat buffer doesn't pay any of those costs.
+
+sqlx 0.8's `sqlx-sqlite` crate ships a `regexp` feature that registers a
+`REGEXP` scalar UDF backed by the Rust `regex` crate, with per-statement auxdata
+caching of compiled patterns. With the UDF available, a SQL `WHERE … REGEXP ?`
+can discard non-matching rows at SQLite's B-tree scan layer — in C — before they
+ever cross the sqlx boundary.
+
+A short-lived design used SQL `LIKE` for patterns that contained no regex
+metacharacters, with a Rust `str::contains` re-verify to enforce
+case-sensitivity (SQLite's `LIKE` is ASCII case-insensitive by default).
+Benchmarking on the real DB showed REGEXP with a literal pattern beat
+LIKE+verify by ~30% wall-time, because LIKE's ASCII case-folding makes it return
+more candidate rows and the `regex` crate compiles a literal pattern to a SIMD
+memmem scan that's at least as fast as LIKE's inner loop.
+
+## Decision
+
+`etp-find` always runs pattern matching inside SQLite via the REGEXP UDF.
+
+1. Enable the `regexp` feature on the sqlx dependency and call `.with_regexp()`
+   on `SqliteConnectOptions` in both `open_db` and `open_memory`. The UDF
+   registers per-connection.
+2. `dao::list_files_matching` / `dao::stream_files_matching` run the query
+   `WHERE (<full_path>) REGEXP ?`, where `<full_path>` is the existing SQL
+   concatenation already used elsewhere in the DAO.
+3. `-i` is expressed as a `(?i)` prefix on the pattern string before binding, so
+   the Rust `regex` crate applies Unicode simple case folding inside the UDF.
+   There is no separate case-insensitive SQL operator.
+4. When `FilterConfig::include_system_files` is false, a second REGEXP filter
+   (`AND NOT (<full_path>) REGEXP ?`) is added to the WHERE clause. The
+   system-path regex is built at call time from `FilterConfig::system_patterns`
+   via `regex::escape` with component-anchored alternation:
+   `(?:^|/)(?:<patterns>)(?:$|/)`. SQLite short-circuits `AND` chains, so rows
+   that fail the user pattern never trigger the system-regex evaluation.
+5. The `should_show_post_sql` branch of `FilterConfig` skips the expensive
+   `is_system_path` walk over every path component, since the SQL layer has
+   already applied the system filter when one was passed. Dotfile and user
+   exclude checks remain Rust-side against the filename alone.
+6. Four static `&'static str` query constants cover the four combinations of
+   scan-id filter × system-filter. A helper `find_query_str(bool, bool)` picks
+   the right one so the streaming API can hand sqlx a static pointer.
+
+Pattern input is validated up front via `ops::compile_pattern` in each binary
+caller so bad regex syntax fails with a clear Rust error message rather than
+sqlx's less helpful `SQLITE_CONSTRAINT` error at execution time.
+
+### Evolution
+
+An earlier version of this work (committed on the same branch, then removed)
+used a dispatch matrix:
+
+| Pattern           | `-i` | SQL op          | Rust post-filter         |
+| ----------------- | ---- | --------------- | ------------------------ |
+| literal (no meta) | off  | `LIKE … ESCAPE` | `str::contains` re-check |
+| literal           | on   | `REGEXP (?i)…`  | none                     |
+| regex metachars   | off  | `REGEXP …`      | none                     |
+| regex             | on   | `REGEXP (?i)…`  | none                     |
+
+The LIKE path was dropped when benchmarking showed it was slower than REGEXP on
+the same data. Dropping the dispatch removed `is_literal_pattern`,
+`escape_like_pattern`, and two of the SQL query constants — a net reduction of
+~165 lines with no perceptible user-facing change.
+
+## Consequences
+
+- Warm-cache `etp find -i swans` on the 824k-row music DB drops from 5.52 s →
+  0.96 s wall, and user CPU from 8.81 s → 0.89 s. The speedup is dominated by
+  avoided sqlx row materialization, not regex engine performance.
+- `etp-find`'s case-sensitivity is a property of the compiled regex, not of the
+  SQL operator. `-i` expands to a `(?i)` prefix in Rust, which means full
+  Unicode _simple_ case folding (e.g., `Björk` ↔ `björk`, `Σ` ↔ `σ`). The `ß` ↔
+  `SS` 1:2 mapping is _full_ case folding, which the `regex` crate does not
+  implement — documented with explicit tests in `find_sql_pushdown.rs`.
+- When `include_system_files` is false, system paths never cross the sqlx
+  boundary. Real gain is pattern-dependent: narrow patterns (`swans`) see little
+  difference because the user REGEXP already rejects most rows; patterns that
+  match many system files (`jpg` matching @eaDir thumbnails) benefit more.
+- The system-regex is rebuilt per call from `FilterConfig::system_patterns`.
+  This honors runtime-config overrides but inherits the same caveat as
+  `is_system_path` — if a user adds a generic name like `music` to their system
+  patterns, the regex will match every path containing that component. This is a
+  pre-existing configuration footgun, not new.
+- `sqlx-sqlite`'s auxdata caching compiles each `?`-bound regex once per
+  statement, so there is no per-row regex compilation cost even with two REGEXP
+  arguments.
+- `finder::matches_pattern` is no longer called by any production path (kept for
+  its test coverage of the `FindMatch` struct layout). A future cleanup can
+  remove it once all callers of the old `Regex`-based API are confirmed dropped.
+- A CTE refactor was considered (computing `full_path` once in a WITH clause to
+  avoid re-evaluating the concat in the system-filter variant) but benchmarked
+  as no faster on the production DB. Not adopted.

--- a/docs/adrs/2026-04-19-01-regexp-pushdown-for-find.md
+++ b/docs/adrs/2026-04-19-01-regexp-pushdown-for-find.md
@@ -103,9 +103,9 @@ the same data. Dropping the dispatch removed `is_literal_pattern`,
 - `sqlx-sqlite`'s auxdata caching compiles each `?`-bound regex once per
   statement, so there is no per-row regex compilation cost even with two REGEXP
   arguments.
-- `finder::matches_pattern` is no longer called by any production path (kept for
-  its test coverage of the `FindMatch` struct layout). A future cleanup can
-  remove it once all callers of the old `Regex`-based API are confirmed dropped.
+- `finder.rs` shrinks to just the `FindMatch` struct. The old
+  `matches_pattern(&FileRecord, &Regex) -> Option<FindMatch>` helper and its
+  tests were removed once the SQL path was the only production caller.
 - A CTE refactor was considered (computing `full_path` once in a WITH clause to
   avoid re-evaluating the concat in the system-filter variant) but benchmarked
   as no faster on the production DB. Not adopted.


### PR DESCRIPTION
## Summary

- `etp find` now runs pattern matching inside SQLite via the REGEXP UDF, so non-matching rows never cross the sqlx/Rust boundary. Median warm-cache `etp find -i swans` against an 824k-row music DB dropped from **5.52s → 0.96s** wall (and 8.81s → 0.89s CPU time).
- When `--include-system-files` is off (the default), the query also filters `@eaDir`, `.etp.db`, `#recycle`, etc. at the SQL layer using a second REGEXP against a regex built from `FilterConfig::system_patterns`.
- `scan_to_db` gained verbose `phase: …` markers so the next time a scan looks stuck in one of its post-walk phases we can diagnose it in one run. Added after chasing a ~90-minute hang on a first-time NAS music scan (turned out to be cold filesystem caches, not a code bug — subsequent scans run in ~7 min).
- Clippy 1.95 flagged `unnecessary_sort_by` on `extension_counts` — fixed.

## Changes by commit

1. `feat: add verbose phase markers to scan_to_db` — emits per-phase timings when `-v` is set, plus 30-second walk/reconcile progress lines so very long scans report liveness.
2. `fix: clippy unnecessary_sort_by on extension_counts` — `sort_by(|a,b| b.1.cmp(&a.1))` → `sort_by_key(|r| std::cmp::Reverse(r.1))`.
3. `test: update csv-verbose trycmd snapshot for new phase markers` — snapshot catches up to the new verbose output.
4. `perf: push etp-find pattern matching into SQLite` — enable sqlx's `regexp` feature + `.with_regexp()`, add `list_files_matching` / `stream_files_matching` that do the pattern match in SQL.
5. `test: pin case-sensitivity matrix for etp-find strategies` — matrix tests covering `-i` / no-`-i` × ASCII / non-ASCII / ß-SS-fold cells.
6. `refactor: drop LIKE path; always use REGEXP UDF for etp-find` — dual-path design didn't pay off (REGEXP was actually faster on the NAS DB), so one path now. ~165 lines deleted.
7. `perf: push system-file exclusion into SQL for etp-find` — second REGEXP against a system-path regex built from `FilterConfig::system_patterns`; short-circuits on rows that fail the user pattern.
8. `refactor: simplify review findings` — extract `row_to_file_record`, `bind_find_query`, `log_phase`; hoist `PROGRESS_EVERY` const so reconcile uses the same 30-s cadence as the walk.
9. `chore: update Cargo.lock for sqlx-sqlite regexp feature` — one-line lockfile delta that should have been part of (4).

## Performance (warm cache, music DB, 824k files)

| Query                | Before   | After (this PR) | Speedup |
| -------------------- | -------- | --------------- | ------- |
| `etp find -i swans`  | 5.52s    | 0.96s           | ~5.7×   |
| `etp find Swans`     | —        | 0.89s           | —       |
| user CPU             | 8.81s    | 0.89s           | ~10×    |

## Test plan

- [x] `just check` (cargo fmt + clippy, ruff, pyright, ty, prettier)
- [x] `just test` — 184 Rust tests, 634 Python tests all pass
- [x] Benchmarked warm + cold on NAS against real 278 MB music DB
- [x] Verified `find_sql_pushdown.rs` integration tests cover the dispatch and case-sensitivity matrices (including fixtures for Björk/bjork, Weiße/WEISSE)
- [x] Confirmed system-file SQL filter honors `FilterConfig::include_system_files` via `system_filter_default_hides_eadir_children` + `system_filter_include_shows_eadir_children` tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)